### PR TITLE
Log instead of crashing when calling notify() with a string

### DIFF
--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -72,6 +72,18 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void notify(ReadableMap payload) {
+      if (!payload.hasKey("errorClass")) {
+          logger.warning("Bugsnag could not notify: No error class");
+          return;
+      }
+      if (!payload.hasKey("errorMessage")) {
+          logger.warning("Bugsnag could not notify: No error message");
+          return;
+      }
+      if (!payload.hasKey("stacktrace")) {
+          logger.warning("Bugsnag could not notify: No stacktrace");
+          return;
+      }
       final String errorClass = payload.getString("errorClass");
       final String errorMessage = payload.getString("errorMessage");
       final String rawStacktrace = payload.getString("stacktrace");

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -60,6 +60,11 @@ export class Client {
     }
     const report = new Report(this.config.apiKey, error);
 
+    if (!(error instanceof Error)) {
+      console.warn('Bugsnag could not notify: error must be of type Error');
+      return;
+    }
+
     for (callback in this.config.beforeSendCallbacks) {
       if (callback(report) === false) {
         return;


### PR DESCRIPTION
Prevent client.notify() being called with anything other than an error.

Also for Android, check that the required keys exist to prevent an exception.