### PR TITLE
Handle promise rejections

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -32,7 +32,7 @@ export class Client {
    * Registers a global error handler which sends any uncaught error to
    * Bugsnag before invoking the previous handler, if any.
    */
-  handleUncaughtErrors() {
+  handleUncaughtErrors = () => {
     if (ErrorUtils) {
       const previousHandler = ErrorUtils._globalHandler;
       const bugsnag = this;
@@ -54,7 +54,7 @@ export class Client {
   /**
    * Sends an error report to Bugsnag
    */
-  async notify(error, beforeSendCallback) {
+  notify = async (error, beforeSendCallback) => {
     if (!(error instanceof Error)) {
       console.warn('Bugsnag could not notify: error must be of type Error');
       return;
@@ -76,7 +76,7 @@ export class Client {
     NativeClient.notify(report.toJSON());
   }
 
-  setUser(id, name, email) {
+  setUser = (id, name, email) => {
     NativeClient.setUser({id: id, name: name, email: email });
   }
 
@@ -84,7 +84,7 @@ export class Client {
    * Leaves a 'breadcrumb' log message. The most recent breadcrumbs
    * are attached to subsequent error reports.
    */
-  leaveBreadcrumb(name, metadata) {
+  leaveBreadcrumb = (name, metadata) => {
     if (name.constructor !== String) {
       console.warn('Breadcrumb name must be a String');
       return;
@@ -129,7 +129,7 @@ export class Configuration {
    * Whether reports should be sent to Bugsnag, based on the release stage
    * configuration
    */
-  shouldNotify() {
+  shouldNotify = () => {
     return !this.releaseStage
         || !this.notifyReleaseStages
         || this.notifyReleaseStages.contains(this.releaseStage);
@@ -140,25 +140,25 @@ export class Configuration {
    * it is sent to Bugsnag. The function takes a single parameter which is
    * an instance of Report.
    */
-  registerBeforeSendCallback(callback) {
+  registerBeforeSendCallback = (callback) => {
     this.beforeSendCallbacks.add(callback)
   }
 
   /**
    * Remove a callback from the before-send pipeline
    */
-  unregisterBeforeSendCallback(callback) {
+  unregisterBeforeSendCallback = (callback) => {
     this.beforeSendCallbacks.remove(callback);
   }
 
   /**
    * Remove all callbacks invoked before reports are sent to Bugsnag
    */
-  clearBeforeSendCallbacks() {
+  clearBeforeSendCallbacks = () => {
     this.beforeSendCallbacks = []
   }
 
-  toJSON() {
+  toJSON = () => {
     return {
       apiKey: this.apiKey,
       releaseStage: this.releaseStage,
@@ -197,14 +197,14 @@ export class Report {
    * Attach additional diagnostic data to the report. The key/value pairs
    * are grouped into sections.
    */
-  addMetadata(section, key, value) {
+  addMetadata = (section, key, value) => {
     if (!this.metadata[section]) {
       this.metadata[section] = {};
     }
     this.metadata[section][key] = value;
   }
 
-  toJSON() {
+  toJSON = () => {
     return {
       apiKey: this.apiKey,
       context: this.context,

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -23,6 +23,8 @@ export class Client {
     if (NativeClient) {
       NativeClient.startWithOptions(this.config.toJSON());
       this.handleUncaughtErrors();
+      if (this.config.handlePromiseRejections)
+        this.handlePromiseRejections();
     } else {
       throw new Error('Bugsnag: No native client found. Is BugsnagReactNative installed in your native code project?');
     }
@@ -49,6 +51,16 @@ export class Client {
         }
       });
     }
+  }
+
+  handlePromiseRejections = () => {
+    const tracking = require('promise/setimmediate/rejection-tracking'),
+          client = this;
+    tracking.enable({
+      allRejections: true,
+      onUnhandled: function(id, error) { client.notify(error); },
+      onHandled: function() {}
+    });
   }
 
   /**
@@ -123,6 +135,7 @@ export class Configuration {
     this.notifyReleaseStages = undefined;
     this.releaseStage = undefined;
     this.autoNotify = true;
+    this.handlePromiseRejections = !__DEV__; // prefer banner in dev mode
   }
 
   /**


### PR DESCRIPTION
Here are two small changes to make it easier to report promise rejections to Bugsnag.
1. Replace client functions with fat arrows to ensure they are bound ahead of time. This makes it easier to call `client.notify` as a part of a rejection handler.
2. Add a configuration option, `handlePromiseRejections` which enables catching and reporting any unhandled promise rejection. By default, it is only enabled in release mode, to ensure the banner is presented during development.

Fixes #9
