### PR TITLE
Fix default redbox error handling in development

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -35,8 +35,8 @@ export class Client {
    */
   handleUncaughtErrors = () => {
     if (ErrorUtils) {
-      const previousHandler = ErrorUtils._globalHandler;
-      
+      const previousHandler = ErrorUtils.getGlobalHandler();
+
       ErrorUtils.setGlobalHandler((error, isFatal) => {
         if (this.config.autoNotify) {
           this.notify(error, report => {report.severity = 'error'});


### PR DESCRIPTION
Loading bugsnag currently breaks the default redbox behavior in development. This is because the react native `ErrorUtils` has been changed. The `_globalHandler` member is now private and has been replaced with a [proper getter](https://github.com/facebook/react-native/blob/3137ba993dbc3645832283ab683d18950c4246ed/packager/react-packager/src/Resolver/polyfills/error-guard.js#L33-L35). 