### PR TITLE
Fix breadcrumb crash

### DIFF
--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -112,7 +112,20 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
     while (iterator.hasNextKey()) {
         String key = iterator.nextKey();
         ReadableMap pair = map.getMap(key);
-        output.put(key, pair.getString("value"));
+        switch (pair.getString("type")) {
+            case "boolean":
+                output.put(key, String.valueOf(pair.getBoolean("value")));
+                break;
+            case "number":
+                output.put(key, String.valueOf(pair.getDouble("value")));
+                break;
+            case "string":
+                output.put(key, pair.getString("value"));
+                break;
+            case "map":
+                output.put(key, String.valueOf(readStringMap(pair.getMap("value"))));
+                break;
+        }
     }
     return output;
   }


### PR DESCRIPTION
### Changes

Fixes https://github.com/bugsnag/bugsnag-react-native/issues/32 (see issue for details).

The case statement I added is similar to the one lower down in `DiagnosticsCallback#readObjectMap`. It seems like it would be better to use [`ReadableMap#getType`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java#L26) and switch on [`ReadableType`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableType.java), but I didn't want to change that logic in this PR.

This will probably cause merge conflicts with https://github.com/bugsnag/bugsnag-react-native/pull/29 due to changes in the example app. I'll happily rebase on that PR if that's easier.

### Verification steps

Test with the Android example app:

1. Set the API key to a dashboard you have access to
1. Press "leave breadcrumb"
2. Press "crash"
3. Verify the details in your BugSnag dashboard