### PR TITLE
Conventionalize to fix sneaky breadcrumb logging bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 example*/ios/Pods
 *.bundle
 local.properties
+.idea

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -116,22 +116,24 @@ export class Client {
    * are attached to subsequent error reports.
    */
   leaveBreadcrumb = (name, metadata) => {
-    if (name.constructor !== String) {
-      console.warn('Breadcrumb name must be a String');
+    if (typeof name !== 'string') {
+      console.warn(`Breadcrumb name must be a string, got '${name}'. Discarding.`);
       return;
     }
+
+    // Checks for both `null` and `undefined`.
     if (metadata == undefined) {
       metadata = {};
-    }
-    if (metadata.constructor === String) {
-      metadata = {'message': metadata };
-    }
-    if (!metadata instanceof Object) {
-      console.warn('Breadcrumb metadata is not an Object or String, discarding');
+    } else if (typeof metadata === 'string') {
+      metadata = { 'message': metadata };
+    } else if (typeof metadata !== 'object') {
+      console.warn(`Breadcrumb metadata must be an object or string, got '${metadata}'. Discarding metadata.`);
       metadata = {};
     }
+
     let type = metadata['type'] || 'manual';
     delete metadata['type'];
+
     NativeClient.leaveBreadcrumb({
       name,
       type,

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -270,7 +270,11 @@ const typedMap = function(map) {
     if (!{}.hasOwnProperty.call(map, key)) continue;
 
     const value = map[key];
-    if (typeof value === 'object') {
+
+    // Checks for both `null` and `undefined`.
+    if (value == undefined) {
+      output[key] = {type: 'string', value: String(value)}
+    } else if (typeof value === 'object') {
       output[key] = {type: 'map', value: typedMap(value)};
     } else {
       const type = typeof value;

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -265,6 +265,8 @@ const allowedMapObjectTypes = ['string', 'number', 'boolean'];
 const typedMap = function(map) {
   const output = {};
   for (const key in map) {
+    if (!{}.hasOwnProperty.call(map, key)) continue;
+
     const value = map[key];
     if (value instanceof Object) {
       output[key] = {type: 'map', value: typedMap(value)};

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -274,6 +274,8 @@ const typedMap = function(map) {
       const type = typeof value;
       if (allowedMapObjectTypes.includes(type)) {
         output[key] = {type: type, value: value};
+      } else {
+        console.warn(`Could not serialize breadcrumb data for '${key}': Invalid type '${type}'`);
       }
     }
   }

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -11,7 +11,7 @@ export class Client {
    * Creates a new Bugsnag client
    */
   constructor(apiKeyOrConfig) {
-    if (apiKeyOrConfig.constructor === String) {
+    if (typeof apiKeyOrConfig === 'string') {
       this.config = new Configuration(apiKeyOrConfig);
     } else if (apiKeyOrConfig instanceof Configuration) {
       this.config = apiKeyOrConfig;
@@ -146,10 +146,10 @@ export class Client {
 export class Configuration {
 
   constructor(apiKey) {
-    const metadata = require('../package.json')
+    const metadata = require('../package.json');
     this.version = metadata['version'];
     this.apiKey = apiKey;
-    this.delivery = new StandardDelivery()
+    this.delivery = new StandardDelivery();
     this.beforeSendCallbacks = [];
     this.notifyReleaseStages = undefined;
     this.releaseStage = undefined;
@@ -268,7 +268,7 @@ const typedMap = function(map) {
     if (!{}.hasOwnProperty.call(map, key)) continue;
 
     const value = map[key];
-    if (value instanceof Object) {
+    if (typeof value === 'object') {
       output[key] = {type: 'map', value: typedMap(value)};
     } else {
       const type = typeof value;


### PR DESCRIPTION
This PR makes the code follow more standard JS conventions, fixing several major bugs related to breadcrumb logging. It also tackles a few other cleanup items related to the changes.

1. Properly log objects, booleans, `null`, and `undefined` in breadcrumbs
    - Previously, **all of these values were completely dropped without warning**
1. Use `typeof` in several places instead of various alternatives
    - See [here](http://stackoverflow.com/questions/899574/which-is-best-to-use-typeof-or-instanceof) for more info
    - Fixes a few potential bugs with inheritance and prototype modification
1. ~~Use regular functions instead of closures~~ (previously 22aac3a)
1. Check `hasOwnProperty` before adding to typedMap output
1. Output slightly more helpful warnings
1. Ignore the `.idea` directory created by IntelliJ IDEs

Please see the individual commits for more information and to understand each change as a unit.

---
 
Obsolete:

~~Note: None of these changes should be breaking, except in the following case. The use of regular functions instead of closures means that `this` can refer to the wrapper object in rare cases, for example if you do the following:~~

> ```js
> const bugSnag = new BugSnag(API_KEY);
> export const bugSnagWrapperUtil = {
>     trackError: bugSnag.notify,
> };
> ```
> 
> This is generally a desirable side-effect of using ES6 classes, and can easily be resolved by using a closure to maintain the original `this`:
> 
> ```js
>     trackError: (...params) => bugSnag.notify(...params),
> ```