### PR TITLE
Update iOS header imports for RN 0.40

### DIFF
--- a/cocoa/BugsnagReactNative.h
+++ b/cocoa/BugsnagReactNative.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface BugsnagReactNative: NSObject <RCTBridgeModule>
 

--- a/cocoa/BugsnagReactNative.m
+++ b/cocoa/BugsnagReactNative.m
@@ -1,6 +1,6 @@
 #import "Bugsnag.h"
 #import "BugsnagReactNative.h"
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 BSGBreadcrumbType BreadcrumbTypeFromString(NSString *type) {
     if ([type isEqualToString:@"log"])


### PR DESCRIPTION
As you can see from [RN 0.40 release notes](https://github.com/facebook/react-native/releases/tag/v0.40.0) they have moved ALL native modules on iOS. All packages that use `.h`-files starting with `RCT` they have to be refactored to the new path.

So basically `bugsnag-react-native` won't work with RN 0.40 without this PR! :)