### PR TITLE
Add original error to report object

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -224,6 +224,7 @@ export class Report {
     this.severity = 'warning';
     this.stacktrace = error.stack;
     this.user = {};
+    this.error = error;
   }
 
   /**


### PR DESCRIPTION
Sometimes the error object itself contains some important application context that might need to be reported to Bugsnag. This allows the original error object reported to be available in the report, perhaps to be added to metadata in `beforeSendCallbacks`, for example:

```
configuration.beforeSendCallbacks.push(report => {
    const error = report.error;
    ...
})
```

I thought this was a fairly simple solution, but let me know if there's a better way of doing this.