### PR TITLE
fix: call global error handler regardless of bugsnag reporter

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -39,12 +39,9 @@ export class Client {
 
       ErrorUtils.setGlobalHandler((error, isFatal) => {
         if (this.config.autoNotify) {
-          this.notify(error, report => {report.severity = 'error'}, !!NativeClient.notifyBlocking, () => {
-            if (previousHandler) {
-              previousHandler(error, isFatal);
-            }
-          });
-        } else if (previousHandler) {
+            this.notify(error, report => {report.severity = 'error'}, !!NativeClient.notifyBlocking);
+        }
+        if (previousHandler) {
           previousHandler(error, isFatal);
         }
       });


### PR DESCRIPTION
In the case where one configures releaseStage and notifyReleaseStages and is running a stage that is configured not to report to bugsnag, react native's global error handler is never called. This will make sure that any global error handler will be called regardless of what "shouldNotify()" returns.