### PR TITLE
Allow setting codeBundleId as a config option

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -81,6 +81,7 @@ export class Client {
     }
 
     const report = new Report(this.config.apiKey, error);
+    report.addMetadata('app', 'codeBundleId', this.config.codeBundleId);
 
     for (callback of this.config.beforeSendCallbacks) {
       if (callback(report) === false) {
@@ -156,6 +157,7 @@ export class Configuration {
     this.notifyReleaseStages = undefined;
     this.releaseStage = undefined;
     this.appVersion = undefined;
+    this.codeBundleId = undefined;
     this.autoNotify = true;
     this.handlePromiseRejections = !__DEV__; // prefer banner in dev mode
   }
@@ -199,6 +201,7 @@ export class Configuration {
   toJSON = () => {
     return {
       apiKey: this.apiKey,
+      codeBundleId: this.codeBundleId,
       releaseStage: this.releaseStage,
       notifyReleaseStages: this.notifyReleaseStages,
       endpoint: this.delivery.endpoint,


### PR DESCRIPTION
The `codeBundleId` property is proposed as an alternative to `appVersion` which can be updated every time a new deployment is published, such as by using CodePush. The number would need to be updated before each `release-react` or similar, and match a `codeBundleId` sent with source map uploads.

Related: #35 