### PR TITLE
Fix undefined codeBundleId

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -199,15 +199,21 @@ export class Configuration {
   }
 
   toJSON = () => {
-    return {
+    const json = {
       apiKey: this.apiKey,
-      codeBundleId: this.codeBundleId,
       releaseStage: this.releaseStage,
       notifyReleaseStages: this.notifyReleaseStages,
       endpoint: this.delivery.endpoint,
       appVersion: this.appVersion,
       version: this.version
     };
+
+    // Don't add this prop unless it's been explicitly set, otherwise desymbolication won't work.
+    if (this.codeBundleId !== undefined) {
+      json.codeBundleId = this.codeBundleId;
+    }
+
+    return json;
   }
 }
 

--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -81,7 +81,11 @@ export class Client {
     }
 
     const report = new Report(this.config.apiKey, error);
-    report.addMetadata('app', 'codeBundleId', this.config.codeBundleId);
+
+    // Don't add this prop unless it's been explicitly set, otherwise desymbolication won't work.
+    if (this.config.codeBundleId !== undefined) {
+      report.addMetadata('app', 'codeBundleId', this.config.codeBundleId);
+    }
 
     for (callback of this.config.beforeSendCallbacks) {
       if (callback(report, error) === false) {


### PR DESCRIPTION
I talked to support and it sounds like if `codeBundleId` is `undefined` it will fail to desymbolicate crash logs. Quoting Mike:

> If a codeBundleId is present in the Bugsnag configuration the source map needs to be uploaded with the same codeBundleId specified. See https://docs.bugsnag.com/platforms/react-native/showing-full-stacktraces/#how-should-i-upload-source-maps-if-i-39-m-using-codepush for details.

Tested and verified on an android emulator. The first commit (in `toJSON`) may not be necessary, what do you think?

---

Update from Mike again:

> I've made a change on our end so that anyone using v2.1.0 of bugsnag-react-native won't be affected by this issue (it ignores the "undefined" codeBundleId when applying source maps). The source maps should start getting applied correctly for you. We'll take a look over that PR too though for completeness.