### PR TITLE
fix: send uncaught errors to the original error handler when one should not notify Bugsnag

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -38,7 +38,7 @@ export class Client {
       const previousHandler = ErrorUtils.getGlobalHandler();
 
       ErrorUtils.setGlobalHandler((error, isFatal) => {
-        if (this.config.autoNotify) {
+        if (this.config.autoNotify && this.config.shouldNotify()) {
           this.notify(error, report => {report.severity = 'error'}, !!NativeClient.notifyBlocking, () => {
             if (previousHandler) {
               previousHandler(error, isFatal);


### PR DESCRIPTION
Added a check for shouldNotify before notifying Bugsnag of any uncaught error. This error was found using releaseStages, and running the app with a releaseStage that should not notify. Since it should not notify, the callback was never called. And with that, the previousHandler was never called.