### PR TITLE
Add warning when breadcrumb name exceeds max length

### DIFF
--- a/lib/Bugsnag.js
+++ b/lib/Bugsnag.js
@@ -2,6 +2,8 @@ import { NativeModules } from 'react-native';
 
 const NativeClient = NativeModules.BugsnagReactNative;
 
+const BREADCRUMB_MAX_LENGTH = 30;
+
 /**
  * A Bugsnag monitoring and reporting client
  */
@@ -120,6 +122,10 @@ export class Client {
     if (typeof name !== 'string') {
       console.warn(`Breadcrumb name must be a string, got '${name}'. Discarding.`);
       return;
+    }
+
+    if (name.length > BREADCRUMB_MAX_LENGTH) {
+      console.warn(`Breadcrumb name exceeds ${BREADCRUMB_MAX_LENGTH} characters (it has ${name.length}): ${name}. It will be truncated.`);
     }
 
     // Checks for both `null` and `undefined`.


### PR DESCRIPTION
Anecdotally, it appears that breadcrumb names get truncated at 30 characters. I didn't see this specifically mentioned in the docs, but a few of my events were truncated online so it seems like it would be good to have a warning for this.