### PR TITLE
Don't remove type property with mutation

### DIFF
--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -139,12 +139,13 @@ export class Client {
     }
 
     let type = metadata['type'] || 'manual';
-    delete metadata['type'];
+    const breadcrumbMetaData = { ...metadata };
+    delete breadcrumbMetaData['type'];
 
     NativeClient.leaveBreadcrumb({
       name,
       type,
-      metadata: typedMap(metadata)
+      metadata: typedMap(breadcrumbMetaData)
     });
   }
 }


### PR DESCRIPTION
You should not remove the type property of metadata. It will mutate the original object and can cause some issues in the project which uses this module. It's better to create a new Object and remove the type property there.