### PR TITLE
Add homepage, repository, and bugs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "bugsnag-react-native",
+  "homepage": "https://www.bugsnag.com/platforms/react-native-error-reporting/",
+  "repository": "https://github.com/bugsnag/bugsnag-react-native.git",
+  "bugs": "https://github.com/bugsnag/bugsnag-react-native/issues",
   "version": "2.3.0",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
The npm registry and client use these fields to direct people to the appropriate places to find out more about a package.

I always have to hunt for the repository when a new version is released so that I can find the CHANGELOG. 😄 

Have a great day!