### PR TITLE
Fix nested object serialization in metadata

### DIFF
--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -288,7 +288,7 @@ const typedMap = function(map) {
     const value = map[key];
 
     // Checks for `null`, NaN, and `undefined`.
-    if (value == undefined || isNaN(value)) {
+    if (value == undefined || (typeof value === 'number' && isNaN(value))) {
       output[key] = {type: 'string', value: String(value)}
     } else if (typeof value === 'object') {
       output[key] = {type: 'map', value: typedMap(value)};


### PR DESCRIPTION
Nested objects are being prematurely stringified when attached as metadata. This patch refines the NaN check in f847a7390fe3683c0723280de18c169715017ccc to ensure it is only applied to numbers.

Fixes #132 