### PR TITLE
Replace PropTypes from React with form prop-types package

### DIFF
--- a/examples/plain/app/components/scenes/main.js
+++ b/examples/plain/app/components/scenes/main.js
@@ -1,8 +1,9 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Navigator } from 'react-native-deprecated-custom-components';
 import { List } from 'react-native-elements';
 import ListItem from '../list_item';
+import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   container: {

--- a/examples/plain/app/components/scenes/register.js
+++ b/examples/plain/app/components/scenes/register.js
@@ -1,7 +1,8 @@
 import bugsnag from 'lib/bugsnag';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
 import { FormLabel, FormInput, Button } from 'react-native-elements'
+import PropTypes from 'prop-types'
 
 const styles = StyleSheet.create({
   container: { alignSelf: 'stretch', flex: 1, backgroundColor: '#fff',

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "babel-jest": "^21.0.2",
     "babel-preset-react-native": "^1.9.1",
     "jest": "^21.1.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
   }
 }

--- a/test-harness/app/components/scenes/main.js
+++ b/test-harness/app/components/scenes/main.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { View, Navigator, StyleSheet } from 'react-native';
 import { List } from 'react-native-elements';
 import ListItem from '../list_item';
+import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   container: {

--- a/test-harness/app/components/scenes/register.js
+++ b/test-harness/app/components/scenes/register.js
@@ -1,7 +1,8 @@
 import bugsnag from 'lib/bugsnag';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
 import { FormLabel, FormInput, Button } from 'react-native-elements'
+import PropTypes from 'prop-types'
 
 const styles = StyleSheet.create({
   container: { alignSelf: 'stretch', flex: 1, backgroundColor: '#fff',


### PR DESCRIPTION
See https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes
Also seems to be breaking on react@16.0.0-beta.5 and react-native@0.49.3