### PR TITLE
Make console breadcrumbs safe to use

### DIFF
--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -182,10 +182,11 @@ export class Client {
             severity: /^group/.test(method) ? 'log' : method,
             message: args
               .map(arg => {
+                let stringified
                 // do the best/simplest stringification of each argument
-                let stringified = arg.toString()
+                try { stringified = String(arg) } catch (e) {}
                 // unless it stringifies to [object Object], use the toString() value
-                if (stringified !== '[object Object]') return stringified
+                if (stringified && stringified !== '[object Object]') return stringified
                 // otherwise attempt to JSON stringify (with indents/spaces)
                 try { stringified = JSON.stringify(arg, null, 2) } catch (e) {}
                 // any errors, fallback to [object Object]

--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -192,9 +192,9 @@ export class Client {
             })
             .join('\n')
         });
-        console[method]._restore = () => { console[method] = originalFn }
         originalFn.apply(console, args);
       }
+      console[method]._restore = () => { console[method] = originalFn }
     });
   }
 


### PR DESCRIPTION
While the console breadcrumbs are great in concept, they've actually led to more crashes in our app than they've helped to diagnose. This PR resolves the underlying issue and adds safeguards to prevent other undiagnosed issues from crashing people's apps.

**The underlying issue**

If a `console.log` statement receives `null` or `undefined` as an argument, the code will throw a `TypeError` because you cannot call `toString()` on these values. In all cases, it's safer to use the `String` constructor than to call `toString()` on a value. (The former will ultimately delegate to `toString()` if defined, but will gracefully handle primitives like `null` and `undefined`.)

**The safeguard**

As new features are added to the tracker, it's important to wrap them in a top-most `try/catch`. We all make mistakes and cannot fully anticipate whether new code is going to result in problems. However, a top-level `try/catch` is an inexpensive way to mitigate the fallout from any unforeseen corner cases.

These precautions are especially important for a product like this.