### PR TITLE
Update typescript defs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ directory as bugsnag-react-native:
 make ANDROID_VERSION=X IOS_VERSION=X upgrade_vendor
 ```
 
+- Upgrade TypeScript definitions if the JavaScript has changed.
+
 ### Release Checklist
 Please follow the testing instructions in [the platforms release checklist](https://github.com/bugsnag/platforms-release-checklist/blob/master/README.md), and any additional steps directly below.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,8 @@ export class Configuration {
   public codeBundleId?: string;
   public autoNotify: boolean;
   public handlePromiseRejections: boolean;
+  public autoCaptureSessions: boolean;
+  public automaticallyCollectBreadcrumbs: boolean;
 
   constructor(apiKey?: string);
 
@@ -41,6 +43,8 @@ export class Configuration {
 
   public clearBeforeSendCallbacks(): void;
 
+  public startSession(): void;
+
   public toJSON(): any;
 }
 
@@ -48,8 +52,9 @@ type BeforeSend = (report: Report) => boolean | void;
 
 export class StandardDelivery {
   public endpoint: string;
+  public sessionsEndpoint: string;
 
-  constructor(endpoint: string);
+  constructor(endpoint: string, sessionsEndpoint: string);
 }
 
 export interface IMetadata {

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,12 @@ export class Client {
 
   public clearUser(): void;
 
+  public startSession(): void;
+
+  public enableConsoleBreadcrumbs(): void;
+
+  public disableConsoleBreadCrumbs(): void;
+
   public leaveBreadcrumb(name: string, metadata?: IMetadata | string): void;
 }
 
@@ -30,6 +36,7 @@ export class Configuration {
   public handlePromiseRejections: boolean;
   public autoCaptureSessions: boolean;
   public automaticallyCollectBreadcrumbs: boolean;
+  public consoleBreadcrumbsEnabled: boolean;
 
   constructor(apiKey?: string);
 
@@ -42,8 +49,6 @@ export class Configuration {
   ): void;
 
   public clearBeforeSendCallbacks(): void;
-
-  public startSession(): void;
 
   public toJSON(): any;
 }


### PR DESCRIPTION
Updates TypeScript definitions as types have changed since the [last edit](https://github.com/bugsnag/bugsnag-react-native/compare/v2.7.0...master). Also adds a note to the Contributing instructions to prevent this in future