### PR TITLE
Fix missing variable declaration

### DIFF
--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -97,7 +97,7 @@ export class Client {
     const report = new Report(this.config.apiKey, error, _handledState);
     report.addMetadata('app', 'codeBundleId', this.config.codeBundleId);
 
-    for (callback of this.config.beforeSendCallbacks) {
+    for (let callback of this.config.beforeSendCallbacks) {
       if (callback(report, error) === false) {
         if (postSendCallback)
           postSendCallback(false);


### PR DESCRIPTION
Unfortunately, the lack of declaration was causing a crash in the `notify` function when I had a `beforeSendCallback` installed.

Perhaps you could setup a linter to catch some of these issues?