### PR TITLE
Rework construction of `breadcrumbMetaData`

### DIFF
--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -157,9 +157,10 @@ export class Client {
       metadata = {};
     }
 
-    let type = metadata['type'] || 'manual';
-    const breadcrumbMetaData = { ...metadata };
-    delete breadcrumbMetaData['type'];
+    const {
+      type = 'manual',
+      ...breadcrumbMetaData
+    } = metadata;
 
     NativeClient.leaveBreadcrumb({
       name,


### PR DESCRIPTION
Hi,

After upgrading to React Native 0.53 we got a warning about `One of the sources for assign has an enumerable key on the prototype chain` when trying to leave breadcrumbs.

![simulator screen shot - iphone x - 2018-03-13 at 14 39 52](https://user-images.githubusercontent.com/213073/37349412-a8fac578-26d6-11e8-8ce4-d0db203df029.png)

Tracking down the issue to the line that throws the exception, this turned out to be the culprit:

```
    let type = metadata['type'] || 'manual';
    const breadcrumbMetaData = { ...metadata };
    delete breadcrumbMetaData['type'];
```

This snippet basically extracts the `type` from the `metadata` and then creates a new object `breadcrumbMetaData` that contains all `metadata` except for the `type`.

In this PR I've reworked the code so that it leverages the ES2015 syntax by destructuring the object and rest spreading all that's left into the new `breadcrumbMetaData` object.

```
    const {
      type = 'manual',
      ...breadcrumbMetaData
    } = metadata;
```

A detailed writeup on this technique can be found [here](https://www.bram.us/2018/01/10/javascript-removing-a-property-from-an-object-immutably-by-destructuring-it/).

The net result is the same, and the error no longer is being triggered.