### PR TITLE
fix(Errors): Enable nativeSerializer to handle Error objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "index.d.ts",
   "nativePackage": true,
   "dependencies": {
+    "iserror": "^0.0.2",
     "promise": "^7",
     "prop-types": "^15.6.0"
   },

--- a/src/NativeSerializer.js
+++ b/src/NativeSerializer.js
@@ -1,3 +1,5 @@
+const isError = require('iserror')
+
 const allowedMapObjectTypes = [ 'string', 'number', 'boolean' ]
 
 /**
@@ -7,7 +9,7 @@ const allowedMapObjectTypes = [ 'string', 'number', 'boolean' ]
 const serializeForNativeLayer = (map, maxDepth = 10, depth = 0, seen = new Set()) => {
   seen.add(map)
   const output = {}
-  if (map instanceof Error) {
+  if (isError(map)) {
     map = extractErrorDetails(map)
   }
   for (const key in map) {
@@ -39,11 +41,8 @@ const serializeForNativeLayer = (map, maxDepth = 10, depth = 0, seen = new Set()
 }
 
 const extractErrorDetails = (err) => {
-  const {message, stack} = err
-  return {
-    message: message,
-    stack: stack
-  }
+  const { message, stack, name } = err
+  return { message, stack, name }
 }
 
-export default serializeForNativeLayer
+module.exports = serializeForNativeLayer

--- a/src/NativeSerializer.js
+++ b/src/NativeSerializer.js
@@ -7,6 +7,9 @@ const allowedMapObjectTypes = [ 'string', 'number', 'boolean' ]
 const serializeForNativeLayer = (map, maxDepth = 10, depth = 0, seen = new Set()) => {
   seen.add(map)
   const output = {}
+  if (map instanceof Error) {
+    map = extractErrorDetails(map)
+  }
   for (const key in map) {
     if (!{}.hasOwnProperty.call(map, key)) continue
 
@@ -33,6 +36,14 @@ const serializeForNativeLayer = (map, maxDepth = 10, depth = 0, seen = new Set()
     }
   }
   return output
+}
+
+const extractErrorDetails = (err) => {
+  const {message, stack} = err
+  return {
+    message: message,
+    stack: stack
+  }
 }
 
 export default serializeForNativeLayer

--- a/src/__tests__/NativeSerializer.test.js
+++ b/src/__tests__/NativeSerializer.test.js
@@ -144,4 +144,8 @@ test('serializeForNativeLayer handles error objects', () => {
   })
   expect(serialized['stack']['type']).toEqual('string')
   expect(serialized['stack']['value'].length).toBeGreaterThan(0)
+  expect(serialized['name']).toEqual({
+    type: 'string',
+    value: 'Error'
+  })
 })

--- a/src/__tests__/NativeSerializer.test.js
+++ b/src/__tests__/NativeSerializer.test.js
@@ -134,3 +134,14 @@ test('serializeForNativeLayer handles deep nesting', () => {
     }
   })
 })
+
+test('serializeForNativeLayer handles error objects', () => {
+  const err = new Error('Oh no')
+  const serialized = serializeForNativeLayer(err)
+  expect(serialized['message']).toEqual({
+    type: 'string',
+    value: 'Oh no'
+  })
+  expect(serialized['stack']['type']).toEqual('string')
+  expect(serialized['stack']['value'].length).toBeGreaterThan(0)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,6 +2384,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+iserror@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/iserror/-/iserror-0.0.2.tgz#bd53451fe2f668b9f2402c1966787aaa2c7c0bf5"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"


### PR DESCRIPTION
## Goal

Fixes #239, extracting the stack and message from a given `Error` class before serialising it.

## Design

Error objects do not have an iterator therefore are ignored by the `for` loop.  My initial thoughts were to add an iterator using `Object.keys` to extract all properties into a map, but the Error object does not respond to this either.

## Changeset

### Added

Added non-exported method `extractErrorDetails` to `NativeSerializer` that takes an error and returns an object with the Errors `message` and `stack` properties.

## Tests

Added a unit test to `NativeSerializer.test`

## Discussion

### Linked issues

Fixes #239 

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
