### PR TITLE
Remove Gradle warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,6 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.5.0'
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.bugsnag:bugsnag-android:4.5.0'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

