### PR TITLE
Release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 2.11.0 (2018-09-28)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* (iOS) Upgrade to bugsnag-cocoa v5.17.0
+  * Capture trace of error reporting thread and identify with boolean flag
+    [#303](https://github.com/bugsnag/bugsnag-cocoa/pull/303)
+  * Prevent potential crash in session delivery during app teardown
+    [#308](https://github.com/bugsnag/bugsnag-cocoa/pull/308)
+* (Android) Upgrade to bugsnag-android v4.8.1
+  * Capture trace of error reporting thread and identify with boolean flag
+    [#355](https://github.com/bugsnag/bugsnag-android/pull/355)
+  * Add compatibility with bugsnag-android-ndk v4.8.1 for C/C++ crash handling support
+    [#369](https://github.com/bugsnag/bugsnag-android/pull/369)
+
 ## 2.10.3 (2018-09-14)
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,3 +120,5 @@ Note: the manual installation instructions for React Native are in a [separate s
 - [ ] Do the installation instructions work using the released artefact?
 - [ ] Can a freshly created example app send an error report from a release build, using the released artefact?
 - [ ] Do the existing example apps send an error report using the released artefact?
+- [ ] *If bugsnag-android has been updated,* update the exact version number of
+      bugsnag-android-ndk to use in the "enhanced native integration" guide.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ endif
 	@sed -i '' "s/\"version\": \".*\",/\"version\": \"$(VERSION)\",/" package.json
 	@sed -i '' "s/documentation-.*-blue.svg/documentation-$(VERSION)-blue.svg/" README.md
 	@sed -i '' "s/versionName \'.*\'/versionName \'$(VERSION)\'/" android/build.gradle
+	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 
 
 # Makes a release and pushes to github/npm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bugsnag exception reporter for React Native
-[![Documentation](https://img.shields.io/badge/documentation-2.10.3-blue.svg)](http://docs.bugsnag.com/platforms/react-native/)
+[![Documentation](https://img.shields.io/badge/documentation-2.11.0-blue.svg)](http://docs.bugsnag.com/platforms/react-native/)
 
 Automatic [React Native crash reporting](https://www.bugsnag.com/platforms/react-native-error-reporting/) with Bugsnag helps you detect both native OS and JavaScript errors in your React Native apps.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 4
-        versionName '2.10.3'
+        versionName '2.11.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,6 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.8.1'
+    compile 'com.bugsnag:bugsnag-android:4.8.2'
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,6 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.5.0'
+    compile 'com.bugsnag:bugsnag-android:4.8.1'
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -381,9 +381,9 @@ class DiagnosticsCallback implements Callback {
 
     @Override
     public void beforeNotify(Report report) {
-        report.setNotifierName(NOTIFIER_NAME);
-        report.setNotifierURL(NOTIFIER_URL);
-        report.setNotifierVersion(String.format("%s (Android %s)",
+        report.getNotifier().setName(NOTIFIER_NAME);
+        report.getNotifier().setURL(NOTIFIER_URL);
+        report.getNotifier().setVersion(String.format("%s (Android %s)",
                                                 libraryVersion,
                                                 bugsnagAndroidVersion));
 

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagApiClient.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagApiClient.m
@@ -135,6 +135,10 @@
     return request;
 }
 
+- (void)dealloc {
+    [self.sendQueue cancelAllOperations];
+}
+
 @end
 
 @implementation BSGDelayOperation

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
@@ -41,7 +41,7 @@
 #import <AppKit/AppKit.h>
 #endif
 
-NSString *const NOTIFIER_VERSION = @"5.16.4";
+NSString *const NOTIFIER_VERSION = @"5.17.0";
 NSString *const NOTIFIER_URL = @"https://github.com/bugsnag/bugsnag-cocoa";
 NSString *const BSTabCrash = @"crash";
 NSString *const BSAttributeDepth = @"depth";

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingApiClient.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingApiClient.m
@@ -19,8 +19,11 @@
 }
 
 - (void)deliverSessionsInStore:(BugsnagSessionFileStore *)store {
+    NSString *apiKey = [self.config.apiKey copy];
+    NSURL *sessionURL = [self.config.sessionURL copy];
+
     [self.sendQueue addOperationWithBlock:^{
-        if (!self.config.apiKey) {
+        if (!apiKey) {
             bsg_log_err(@"No API key set. Refusing to send sessions.");
             return;
         }
@@ -41,16 +44,16 @@
         if (sessionCount > 0) {
             NSDictionary *HTTPHeaders = @{
                                           @"Bugsnag-Payload-Version": @"1.0",
-                                          @"Bugsnag-API-Key": self.config.apiKey,
+                                          @"Bugsnag-API-Key": apiKey,
                                           @"Bugsnag-Sent-At": [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
                                           };
             [self sendData:payload
                withPayload:[payload toJson]
-                     toURL:self.config.sessionURL
+                     toURL:sessionURL
                    headers:HTTPHeaders
               onCompletion:^(id data, BOOL success, NSError *error) {
                   if (success && error == nil) {
-                      bsg_log_info(@"Sent %lu sessions to Bugsnag", (unsigned long)sessionCount);
+                      bsg_log_info(@"Sent %lu sessions to Bugsnag", (unsigned long) sessionCount);
 
                       for (NSString *fileId in fileIds) {
                           [store deleteFileWithId:fileId];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://www.bugsnag.com/platforms/react-native-error-reporting/",
   "repository": "https://github.com/bugsnag/bugsnag-react-native.git",
   "bugs": "https://github.com/bugsnag/bugsnag-react-native/issues",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Upgrades bugsnag-cocoa to 5.17.0 and bugsnag-android to (speculatively) 4.8.2, as it requires bugsnag/bugsnag-android#370 being released first.

**Cannot be merged** until bugsnag-android@4.8.2 is out (or whichever version number matches the ThreadSafe changes).