### PR TITLE
Fix for javascript unhandled errors not being reported

### DIFF
--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -107,13 +107,9 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
                               readStringMap(options.getMap("metadata")));
   }
 
-  @ReactMethod
-  public void notify(ReadableMap payload) {
-      notifyBlocking(payload, false, null);
-  }
 
   @ReactMethod
-  public void notifyBlocking(ReadableMap payload, boolean blocking, com.facebook.react.bridge.Callback callback) {
+  public void notify(ReadableMap payload, com.facebook.react.bridge.Promise promise) {
       if (!payload.hasKey("errorClass")) {
           logger.warning("Bugsnag could not notify: No error class");
           return;
@@ -142,10 +138,11 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
       map.put("severity", severity);
       map.put("severityReason", severityReason);
 
-      Bugsnag.internalClientNotify(exc, map, blocking, handler);
+      //always block 
+      Bugsnag.internalClientNotify(exc, map, true, handler);
 
-      if (callback != null)
-        callback.invoke();
+      if (promise != null)
+        promise.resolve(null);
   }
 
   @ReactMethod

--- a/cocoa/BugsnagReactNative.h
+++ b/cocoa/BugsnagReactNative.h
@@ -2,6 +2,14 @@
 
 #import <React/RCTBridgeModule.h>
 
+#if __has_include(<React/RCTBridge.h>)
+// React Native >= 0.40
+#import <React/RCTBridge.h>
+#else
+// React Native <= 0.39
+#import "RCTBridge.h"
+#endif
+
 @class BugsnagConfiguration;
 
 @interface BugsnagReactNative: NSObject <RCTBridgeModule>

--- a/cocoa/BugsnagReactNative.m
+++ b/cocoa/BugsnagReactNative.m
@@ -141,7 +141,9 @@ NSArray *BSGParseJavaScriptStacktrace(NSString *stacktrace, NSNumberFormatter *f
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(notify:(NSDictionary *)options) {
+RCT_EXPORT_METHOD(notify:(NSDictionary *)options
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
     if (![Bugsnag bugsnagStarted]) {
         return;
     }
@@ -185,6 +187,8 @@ RCT_EXPORT_METHOD(notify:(NSDictionary *)options) {
                 targetMetadata[sectionKey] = section;
             }
             report.metaData = targetMetadata;
+
+            resolve(@"");
         }
     }];
 }


### PR DESCRIPTION
## Problem
On iOS, a majority of our unhandled javascript errors are not reaching our dashboard... 

## Reason
When the Bugsnag Javascript library tries to notify the Native SDK of the javascript error, that operation is NOT blocking. This means that in the very next line of code in the Bugsnag JS SDK, is to re-throw the Error, which will then terminate your app. If your error has a large number of stack frames (more than the [Bugsnag Example App](https://github.com/bugsnag/bugsnag-react-native/tree/master/examples)), then there is a chance that your error will NOT get reported to the dashboard because the Native SDK gets terminated from the re-thrown Error. 

This is because the Bugsnag library does not wait for the internal native [Bugsnag error reporting method](https://github.com/bugsnag/bugsnag-react-native/blob/master/cocoa/BugsnagReactNative.m#L155) to complete before it re-throws the exception. In the case of a large JS error, a few milliseconds later, React and CoreFoundation will simply re-throw the native error, which will cut the head off of the currently parsing/persisting javascript exception. 

**Steps to repro..**
Create a complex call hierarchy for a javascript error. 
Trigger this javascript error in a release/production build. 
Observe that there is no report on the dashboard. 



## Changeset

The underlying problem is [here](https://github.com/bugsnag/bugsnag-react-native/blob/master/src/Bugsnag.js#L51). 
On iOS, this `previousHandler` is called mere milliseconds after the original exception is still going across the bridge, or is currently being worked on by the native iOS SDK.
The `previousHandler` in this case is React/CoreFoundation which will terminate the process, which will not allow the Bugsnag SDK to fully process the unhandled javascript error. 

The solution to this is to simply block/wait on ALL calls to notify. 

I made the call to `notify` promise based (on BOTH platforms)

```
NativeClient.notify(payload).then(() => {
      //let the native SDK do its thing to persist the error
      setTimeout(() =>{
        if(postSendCallback){
          postSendCallback();
        }
      }, callbackDelay);
    });
```

We are going to maintain our fork until this gets resolved, but I imagine this is happening for many of your other customers... 




## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
