### PR TITLE
Add proguard consumer rules to retain JavascriptException class

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,7 @@ android {
         targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 4
         versionName '2.12.6'
+        consumerProguardFiles 'proguard-rules.pro'
     }
 }
 

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.facebook.react.common.JavascriptException { *; }


### PR DESCRIPTION
## Goal

Any exception of the type `com.facebook.react.common.JavascriptException` should be ignored by the notifier. This is because any unhandled JS error is captured in both the Android + JS layers. As the JS error contains more relevant information, the Android exception is discarded to avoid duplicates.

If ProGuard is enabled, the class name used to [filter exceptions](https://github.com/bugsnag/bugsnag-react-native/blob/master/android/src/main/java/com/bugsnag/BugsnagReactNative.java#L213)  will be obfuscated, and therefore two errors will be sent for every unhandled JS error triggered.

## Design

Adding a keep rule to the consumer proguard file for the library will cause this class name to be retained if obfuscation is enabled.

## Tests

Sent an unhandled JS exception in the example app with the local artefact integrated, in the following scenarios:

### Before fix

No obfuscation: 1 error
Obfuscated: 2 errors

### After fix

No obfuscation: 1 error
Obfuscated: 1 error