### PR TITLE
Specify maven central as a preferred repository over jcenter

### DIFF
--- a/examples/codepush/android/build.gradle
+++ b/examples/codepush/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
+        mavenCentral()
         jcenter()
         maven { url 'https://maven.google.com' }
         maven {

--- a/examples/plain/android/build.gradle
+++ b/examples/plain/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -24,6 +25,7 @@ allprojects {
     repositories {
         google()
         mavenLocal()
+        mavenCentral()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/features/fixtures/sampler/android/build.gradle
+++ b/features/fixtures/sampler/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -24,6 +25,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
+        mavenCentral()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/test-harness/android/build.gradle
+++ b/test-harness/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
+        mavenCentral()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
## Goal

Specifying `mavenCentral` as a repository in addition to `jcenter` makes it possible to perform a clean build of the project in the case where one provider suffers downtime.