### PR TITLE
Remove support library dependency to support RN 0.59

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,6 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.12.0'
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.bugsnag:bugsnag-android:4.12.0'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -2,7 +2,6 @@ package com.bugsnag;
 
 import android.app.Activity;
 import android.content.Context;
-import android.support.annotation.NonNull;
 
 import com.bugsnag.android.BreadcrumbType;
 import com.bugsnag.android.Bugsnag;
@@ -434,7 +433,7 @@ class JavaScriptException extends Exception implements JsonStream.Streamable {
         this.rawStacktrace = rawStacktrace;
     }
 
-    public void toStream(@NonNull JsonStream writer) throws IOException {
+    public void toStream(JsonStream writer) throws IOException {
         writer.beginObject();
         writer.name("errorClass").value(name);
         writer.name("message").value(getLocalizedMessage());

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "BugsnagReactNative.podspec"
   ],
   "scripts": {
-    "prepublish": "mkdir -p lib && babel --source-maps --out-dir='lib' --ignore='__tests__' src",
+    "prepare": "mkdir -p lib && babel --source-maps --out-dir='lib' --ignore='__tests__' src",
     "test:unit:js": "jest --coverage src/__tests__",
     "test:lint:js": "standard",
     "test:e2e:js": "bundle exec bugsnag-maze-runner --verbose",


### PR DESCRIPTION
This fixes issues for those upgrading to RN 0.59 and also makes the process easier for those migrating to androidx