### PR TITLE
Run checkstyle and lint on Android code, address existing violations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - yarn install
         - ./node_modules/.bin/react-native link
         - cd android
-        - ./gradlew assembleRelease
+        - ./gradlew lint checkstyle assembleRelease
       licenses:
         -
     - stage: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+Run checkstyle and lint on Android code, address existing violations
+[#452](https://github.com/bugsnag/bugsnag-react-native/pull/336)
+
 ## 2.17.1 (2019-04-24)
 
 Re-release that fixes packaging issue where the previous artefact included duplicate header files, preventing compilation for iOS

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,12 +4,6 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-//gradle.projectsEvaluated {
-    //tasks.withType(JavaCompile) {
-        //options.compilerArgs << "-Xlint:all" << "-Werror"
-    //}
-//}
-
 android {
     buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
     compileSdkVersion safeExtGet('compileSdkVersion', 26)
@@ -20,6 +14,11 @@ android {
         versionCode 4
         versionName '2.16.0'
         consumerProguardFiles 'proguard-rules.pro'
+    }
+    lintOptions {
+        abortOnError true
+        warningsAsErrors true
+        baseline file("lint-baseline.xml")
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,3 +26,17 @@ dependencies {
     compile 'com.bugsnag:bugsnag-android:4.13.0'
     compile 'com.facebook.react:react-native:+'
 }
+
+apply plugin: 'checkstyle'
+
+checkstyle {
+    toolVersion = "8.18"
+}
+
+task("checkstyle", type: Checkstyle) {
+    configFile rootProject.file("config/checkstyle/checkstyle.xml")
+    source  "src/"
+    include "**/*.java"
+    exclude "**/external/**/*.java"
+    classpath = files()
+}

--- a/android/config/checkstyle/checkstyle.xml
+++ b/android/config/checkstyle/checkstyle.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="FileTabCharacter">
+            <property name="eachLine" value="true"/>
+        </module>
+
+    <module name="SuppressWarningsFilter" />
+    <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="4"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="specialImportsRegExp" value="com.bugsnag"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>

--- a/android/lint-baseline.xml
+++ b/android/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="4" by="lint 3.1.4">
+
+    <issue
+        id="GradleDynamicVersion"
+        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (com.facebook.react:react-native:+)"
+        errorLine1="    compile &apos;com.facebook.react:react-native:+&apos;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="27"
+            column="5"/>
+    </issue>
+
+</issues>

--- a/android/src/main/java/com/bugsnag/BugsnagPackage.java
+++ b/android/src/main/java/com/bugsnag/BugsnagPackage.java
@@ -1,0 +1,28 @@
+package com.bugsnag;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+class BugsnagPackage implements ReactPackage {
+
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Collections.<NativeModule>singletonList(new BugsnagReactNative(reactContext));
+    }
+}

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -1,21 +1,13 @@
 package com.bugsnag;
 
-import android.app.Activity;
-import android.content.Context;
-import android.support.annotation.NonNull;
-
 import com.bugsnag.android.BreadcrumbType;
 import com.bugsnag.android.Bugsnag;
-import com.bugsnag.android.Callback;
 import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
-import com.bugsnag.android.JsonStream;
-import com.bugsnag.android.MetaData;
-import com.bugsnag.android.Report;
-import com.bugsnag.android.Severity;
+
+import android.content.Context;
+
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -24,465 +16,274 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.uimanager.ViewManager;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-
+@SuppressWarnings("JavadocMethod")
 public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
-  private ReactContext reactContext;
-  private String libraryVersion;
-  private String bugsnagAndroidVersion;
-  final static Logger logger = Logger.getLogger("bugsnag-react-native");
+    private ReactContext reactContext;
+    private String libraryVersion;
+    private String bugsnagAndroidVersion;
+    static final Logger logger = Logger.getLogger("bugsnag-react-native");
 
-  public static ReactPackage getPackage() {
-    return new BugsnagPackage();
-  }
-
-  public static Client start(Context context) {
-    Client client = Bugsnag.init(context);
-    // The first session starts during JS initialization
-    // Applications which have specific components in RN instead of the primary
-    // way to interact with the application should instead leverage startSession
-    // manually.
-    client.setAutoCaptureSessions(false);
-    return client;
-  }
-
-  public static Client startWithApiKey(Context context, String APIKey) {
-    Client client = Bugsnag.init(context, APIKey);
-    client.setAutoCaptureSessions(false);
-    return client;
-  }
-
-  public static Client startWithConfiguration(Context context, Configuration config) {
-    config.setAutoCaptureSessions(false);
-    return Bugsnag.init(context, config);
-  }
-
-  public BugsnagReactNative(ReactApplicationContext reactContext) {
-    super(reactContext);
-    this.reactContext = reactContext;
-    libraryVersion = null;
-    bugsnagAndroidVersion = null;
-  }
-
-  @Override
-  public String getName() {
-    return "BugsnagReactNative";
-  }
-
-  @ReactMethod
-  public void startSession() {
-      Bugsnag.startSession();
-  }
-
-  @ReactMethod
-  public void stopSession() {
-      Bugsnag.stopSession();
-  }
-
-  @ReactMethod
-  public void resumeSession() {
-      Bugsnag.resumeSession();
-  }
-
-  @ReactMethod
-  public void startWithOptions(ReadableMap options) {
-      String apiKey = null;
-      if (options.hasKey("apiKey")) {
-          apiKey = options.getString("apiKey");
-      }
-      Client client = getClient(apiKey);
-      libraryVersion = options.getString("version");
-      bugsnagAndroidVersion = client.getClass().getPackage().getSpecificationVersion();
-      configureRuntimeOptions(client, options);
-
-      logger.info(String.format("Initialized Bugsnag React Native %s/Android %s",
-                  libraryVersion,
-                  bugsnagAndroidVersion));
-  }
-
-  @ReactMethod
-  public void leaveBreadcrumb(ReadableMap options) {
-      String name = options.getString("name");
-      Bugsnag.leaveBreadcrumb(name,
-                              parseBreadcrumbType(options.getString("type")),
-                              readStringMap(options.getMap("metadata")));
-  }
-
-
-  @ReactMethod
-  public void notify(ReadableMap payload, Promise promise) {
-      if (!payload.hasKey("errorClass")) {
-          logger.warning("Bugsnag could not notify: No error class");
-          return;
-      }
-      if (!payload.hasKey("stacktrace")) {
-          logger.warning("Bugsnag could not notify: No stacktrace");
-          return;
-      }
-      final String errorClass = payload.getString("errorClass");
-      final String errorMessage = payload.getString("errorMessage");
-      final String rawStacktrace = payload.getString("stacktrace");
-
-      logger.info(String.format("Sending exception: %s - %s %s\n",
-                                errorClass, errorMessage, rawStacktrace));
-      JavaScriptException exc = new JavaScriptException(errorClass,
-                                                        errorMessage,
-                                                        rawStacktrace);
-
-      DiagnosticsCallback handler = new DiagnosticsCallback(libraryVersion,
-                                                            bugsnagAndroidVersion,
-                                                            payload);
-
-      Map<String, Object> map = new HashMap<>();
-      String severity = payload.getString("severity");
-      String severityReason = payload.getString("severityReason");
-      map.put("severity", severity);
-      map.put("severityReason", severityReason);
-      boolean blocking = payload.hasKey("blocking") && payload.getBoolean("blocking");
-
-      Bugsnag.internalClientNotify(exc, map, blocking, handler);
-
-      if (promise != null)
-        promise.resolve(null);
-  }
-
-  @ReactMethod
-  public void setUser(ReadableMap userInfo) {
-      String userId = userInfo.hasKey("id") ? userInfo.getString("id") : null;
-      String email = userInfo.hasKey("email") ? userInfo.getString("email") : null;
-      String name = userInfo.hasKey("name") ? userInfo.getString("name") : null;
-      Bugsnag.setUser(userId, email, name);
-  }
-
-  @ReactMethod
-  public void clearUser() {
-      Bugsnag.clearUser();
-  }
-
-  /**
-   * Convert a typed map into a string Map
-   */
-  private Map<String, String> readStringMap(ReadableMap map) {
-    Map<String,String> output = new HashMap<>();
-    ReadableMapKeySetIterator iterator = map.keySetIterator();
-    while (iterator.hasNextKey()) {
-        String key = iterator.nextKey();
-        ReadableMap pair = map.getMap(key);
-        switch (pair.getString("type")) {
-            case "boolean":
-                output.put(key, String.valueOf(pair.getBoolean("value")));
-                break;
-            case "number":
-                output.put(key, String.valueOf(pair.getDouble("value")));
-                break;
-            case "string":
-                output.put(key, pair.getString("value"));
-                break;
-            case "map":
-                output.put(key, String.valueOf(readStringMap(pair.getMap("value"))));
-                break;
-        }
-    }
-    return output;
-  }
-
-  private Client getClient(String apiKey) {
-      Client client;
-      try {
-          client = Bugsnag.getClient();
-      } catch (IllegalStateException exception) {
-          if (apiKey != null) {
-              client = Bugsnag.init(this.reactContext, apiKey);
-          } else {
-              client = Bugsnag.init(this.reactContext);
-          }
-      }
-      return client;
-  }
-
-  private BreadcrumbType parseBreadcrumbType(String value) {
-    for (BreadcrumbType type : BreadcrumbType.values()) {
-        if (type.toString().equals(value)) {
-            return type;
-        }
-    }
-    return BreadcrumbType.MANUAL;
-  }
-
-  private void configureRuntimeOptions(Client client, ReadableMap options) {
-      client.setIgnoreClasses("com.facebook.react.common.JavascriptException");
-      Configuration config = client.getConfig();
-      if (options.hasKey("appVersion")) {
-          String version = options.getString("appVersion");
-          if (version != null && version.length() > 0)
-              client.setAppVersion(version);
-      }
-
-      String notify = null;
-      String sessions = null;
-
-      if (options.hasKey("endpoint")) {
-          notify = options.getString("endpoint");
-      }
-      if (options.hasKey("sessionsEndpoint")) {
-          sessions = options.getString("sessionsEndpoint");
-      }
-
-      if (notify != null && notify.length() > 0) {
-          config.setEndpoints(notify, sessions);
-      } else if (sessions != null && sessions.length() > 0) {
-          logger.warning("The session tracking endpoint should not be set without the error reporting endpoint.");
-      }
-
-
-      if (options.hasKey("releaseStage")) {
-          String releaseStage = options.getString("releaseStage");
-          if (releaseStage != null && releaseStage.length() > 0)
-              client.setReleaseStage(releaseStage);
-      }
-
-      if (options.hasKey("autoNotify")) {
-          if (options.getBoolean("autoNotify")) {
-              client.enableExceptionHandler();
-          } else {
-              client.disableExceptionHandler();
-          }
-      }
-
-      if (options.hasKey("codeBundleId")) {
-          String codeBundleId = options.getString("codeBundleId");
-          if (codeBundleId != null && codeBundleId.length() > 0)
-              client.addToTab("app", "codeBundleId", codeBundleId);
-      }
-
-      if (options.hasKey("notifyReleaseStages")) {
-          ReadableArray stages = options.getArray("notifyReleaseStages");
-          if (stages != null && stages.size() > 0) {
-              String releaseStages[] = new String[stages.size()];
-              for (int i = 0; i < stages.size(); i++) {
-                releaseStages[i] = stages.getString(i);
-              }
-              client.setNotifyReleaseStages(releaseStages);
-          }
-      }
-      if (options.hasKey("automaticallyCollectBreadcrumbs")) {
-          boolean autoCapture = options.getBoolean("automaticallyCollectBreadcrumbs");
-          config.setAutomaticallyCollectBreadcrumbs(autoCapture);
-      }
-      // Process session tracking last in case the effects of other options
-      // should be captured as a part of the session
-      if (options.hasKey("autoCaptureSessions")) {
-          boolean autoCapture = options.getBoolean("autoCaptureSessions");
-          config.setAutoCaptureSessions(autoCapture);
-          if (autoCapture) {
-              // The launch event session is skipped because autoCaptureSessions
-              // was not set when Bugsnag was first initialized. Manually sending a
-              // session to compensate.
-              client.resumeSession();
-          }
-      }
-  }
-}
-
-class BugsnagPackage implements ReactPackage {
-
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
-  @Override
-  public List<ViewManager> createViewManagers(
-          ReactApplicationContext reactContext) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public List<NativeModule> createNativeModules(
-          ReactApplicationContext reactContext) {
-    return Arrays.<NativeModule>asList(new BugsnagReactNative(reactContext));
-  }
-}
-
-/**
- * Attaches report diagnostics before delivery
- */
-class DiagnosticsCallback implements Callback {
-    static final String NOTIFIER_NAME = "Bugsnag for React Native";
-    static final String NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-react-native";
-
-    final private Severity severity;
-    final private String context;
-    final private String groupingHash;
-    final private Map<String, Object> metadata;
-    final private String libraryVersion;
-    final private String bugsnagAndroidVersion;
-
-    DiagnosticsCallback(String libraryVersion,
-                        String bugsnagAndroidVersion,
-                        ReadableMap payload) {
-        this.libraryVersion = libraryVersion;
-        this.bugsnagAndroidVersion = bugsnagAndroidVersion;
-        severity = parseSeverity(payload.getString("severity"));
-        metadata = readObjectMap(payload.getMap("metadata"));
-
-        if (payload.hasKey("context"))
-            context = payload.getString("context");
-        else
-            context = null;
-
-        if (payload.hasKey("groupingHash"))
-            groupingHash = payload.getString("groupingHash");
-        else
-            groupingHash = null;
-
+    public static ReactPackage getPackage() {
+        return new BugsnagPackage();
     }
 
-    Severity parseSeverity(String value) {
-        switch (value) {
-            case "error": return Severity.ERROR;
-            case "info": return Severity.INFO;
-            case "warning":
-            default:
-                return Severity.WARNING;
+    public static Client start(Context context) {
+        Client client = Bugsnag.init(context);
+        // The first session starts during JS initialization
+        // Applications which have specific components in RN instead of the primary
+        // way to interact with the application should instead leverage startSession
+        // manually.
+        client.setAutoCaptureSessions(false);
+        return client;
+    }
+
+    public static Client startWithApiKey(Context context, String apiKey) {
+        Client client = Bugsnag.init(context, apiKey);
+        client.setAutoCaptureSessions(false);
+        return client;
+    }
+
+    public static Client startWithConfiguration(Context context, Configuration config) {
+        config.setAutoCaptureSessions(false);
+        return Bugsnag.init(context, config);
+    }
+
+    public BugsnagReactNative(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+        libraryVersion = null;
+        bugsnagAndroidVersion = null;
+    }
+
+    @Override
+    public String getName() {
+        return "BugsnagReactNative";
+    }
+
+    @ReactMethod
+    public void startSession() {
+        Bugsnag.startSession();
+    }
+
+    @ReactMethod
+    public void stopSession() {
+        Bugsnag.stopSession();
+    }
+
+    @ReactMethod
+    public void resumeSession() {
+        Bugsnag.resumeSession();
+    }
+
+    @ReactMethod
+    public void startWithOptions(ReadableMap options) {
+        String apiKey = null;
+        if (options.hasKey("apiKey")) {
+            apiKey = options.getString("apiKey");
         }
+        Client client = getClient(apiKey);
+        libraryVersion = options.getString("version");
+        bugsnagAndroidVersion = client.getClass().getPackage().getSpecificationVersion();
+        configureRuntimeOptions(client, options);
+
+        logger.info(String.format("Initialized Bugsnag React Native %s/Android %s",
+                libraryVersion,
+                bugsnagAndroidVersion));
+    }
+
+    @ReactMethod
+    public void leaveBreadcrumb(ReadableMap options) {
+        String name = options.getString("name");
+        Bugsnag.leaveBreadcrumb(name,
+                parseBreadcrumbType(options.getString("type")),
+                readStringMap(options.getMap("metadata")));
+    }
+
+
+    @ReactMethod
+    public void notify(ReadableMap payload, Promise promise) {
+        if (!payload.hasKey("errorClass")) {
+            logger.warning("Bugsnag could not notify: No error class");
+            return;
+        }
+        if (!payload.hasKey("stacktrace")) {
+            logger.warning("Bugsnag could not notify: No stacktrace");
+            return;
+        }
+        final String errorClass = payload.getString("errorClass");
+        final String errorMessage = payload.getString("errorMessage");
+        final String rawStacktrace = payload.getString("stacktrace");
+
+        logger.info(String.format("Sending exception: %s - %s %s\n",
+                errorClass, errorMessage, rawStacktrace));
+        JavaScriptException exc = new JavaScriptException(errorClass,
+                errorMessage,
+                rawStacktrace);
+
+        DiagnosticsCallback handler = new DiagnosticsCallback(libraryVersion,
+                bugsnagAndroidVersion,
+                payload);
+
+        Map<String, Object> map = new HashMap<>();
+        String severity = payload.getString("severity");
+        String severityReason = payload.getString("severityReason");
+        map.put("severity", severity);
+        map.put("severityReason", severityReason);
+        boolean blocking = payload.hasKey("blocking") && payload.getBoolean("blocking");
+
+        Bugsnag.internalClientNotify(exc, map, blocking, handler);
+
+        if (promise != null) {
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
+    public void setUser(ReadableMap userInfo) {
+        String userId = userInfo.hasKey("id") ? userInfo.getString("id") : null;
+        String email = userInfo.hasKey("email") ? userInfo.getString("email") : null;
+        String name = userInfo.hasKey("name") ? userInfo.getString("name") : null;
+        Bugsnag.setUser(userId, email, name);
+    }
+
+    @ReactMethod
+    public void clearUser() {
+        Bugsnag.clearUser();
     }
 
     /**
-     * Convert a typed map from JS into a Map
+     * Convert a typed map into a string Map
      */
-    Map<String, Object> readObjectMap(ReadableMap map) {
-        Map<String, Object> output = new HashMap<>();
+    private Map<String, String> readStringMap(ReadableMap map) {
+        Map<String, String> output = new HashMap<>();
         ReadableMapKeySetIterator iterator = map.keySetIterator();
-
         while (iterator.hasNextKey()) {
             String key = iterator.nextKey();
             ReadableMap pair = map.getMap(key);
             switch (pair.getString("type")) {
                 case "boolean":
-                    output.put(key, pair.getBoolean("value"));
+                    output.put(key, String.valueOf(pair.getBoolean("value")));
                     break;
                 case "number":
-                    output.put(key, pair.getDouble("value"));
+                    output.put(key, String.valueOf(pair.getDouble("value")));
                     break;
                 case "string":
                     output.put(key, pair.getString("value"));
                     break;
                 case "map":
-                    output.put(key, readObjectMap(pair.getMap("value")));
+                    output.put(key, String.valueOf(readStringMap(pair.getMap("value"))));
+                    break;
+                default:
                     break;
             }
         }
-
         return output;
     }
 
-    @Override
-    public void beforeNotify(Report report) {
-        report.getNotifier().setName(NOTIFIER_NAME);
-        report.getNotifier().setURL(NOTIFIER_URL);
-        report.getNotifier().setVersion(String.format("%s (Android %s)",
-                                                libraryVersion,
-                                                bugsnagAndroidVersion));
-
-        if (groupingHash != null && groupingHash.length() > 0)
-            report.getError().setGroupingHash(groupingHash);
-        if (context != null && context.length() > 0)
-            report.getError().setContext(context);
-        if (metadata != null) {
-            MetaData reportMetadata = report.getError().getMetaData();
-            for (String tab : metadata.keySet()) {
-                Object value = metadata.get(tab);
-
-                if (value instanceof Map) {
-                    @SuppressWarnings("unchecked") // ignore type erasure when casting Map
-                    Map<String, Object> values = (Map<String, Object>) value;
-
-                    for (String key : values.keySet()) {
-                        reportMetadata.addToTab(tab, key, values.get(key));
-                    }
-                }
+    private Client getClient(String apiKey) {
+        Client client;
+        try {
+            client = Bugsnag.getClient();
+        } catch (IllegalStateException exception) {
+            if (apiKey != null) {
+                client = Bugsnag.init(this.reactContext, apiKey);
+            } else {
+                client = Bugsnag.init(this.reactContext);
             }
         }
-    }
-}
-
-/**
- * Creates a streamable exception with a JavaScript stacktrace
- */
-class JavaScriptException extends Exception implements JsonStream.Streamable {
-
-    private static final String EXCEPTION_TYPE = "browserjs";
-    private static final long serialVersionUID = 1175784680140218622L;
-
-    private final String name;
-    private final String rawStacktrace;
-
-    JavaScriptException(String name, String message, String rawStacktrace) {
-        super(message);
-        this.name = name;
-        this.rawStacktrace = rawStacktrace;
+        return client;
     }
 
-    public void toStream(@NonNull JsonStream writer) throws IOException {
-        writer.beginObject();
-        writer.name("errorClass").value(name);
-        writer.name("message").value(getLocalizedMessage());
-        writer.name("type").value(EXCEPTION_TYPE);
-
-        writer.name("stacktrace");
-        writer.beginArray();
-        for (String rawFrame : rawStacktrace.split("\\n")) {
-            writer.beginObject();
-            String methodComponents[] = rawFrame.split("@", 2);
-            String fragment = methodComponents[0];
-            if (methodComponents.length == 2) {
-                writer.name("method").value(methodComponents[0]);
-                fragment = methodComponents[1];
+    private BreadcrumbType parseBreadcrumbType(String value) {
+        for (BreadcrumbType type : BreadcrumbType.values()) {
+            if (type.toString().equals(value)) {
+                return type;
             }
-
-            int columnIndex = fragment.lastIndexOf(":");
-            if (columnIndex != -1) {
-                String columnString = fragment.substring(columnIndex + 1, fragment.length());
-                try {
-                    int columnNumber = Integer.parseInt(columnString);
-                    writer.name("columnNumber").value(columnNumber);
-                } catch (NumberFormatException e) {
-                    BugsnagReactNative.logger.info(String.format(
-                                "Failed to parse column: '%s'",
-                                columnString));
-                }
-                fragment = fragment.substring(0, columnIndex);
-            }
-
-            int lineNumberIndex = fragment.lastIndexOf(":");
-            if (lineNumberIndex != -1) {
-                String lineNumberString = fragment.substring(lineNumberIndex + 1, fragment.length());
-                try {
-                    int lineNumber = Integer.parseInt(lineNumberString);
-                    writer.name("lineNumber").value(lineNumber);
-                } catch (NumberFormatException e) {
-                    BugsnagReactNative.logger.info(String.format(
-                                "Failed to parse lineNumber: '%s'",
-                                lineNumberString));
-                }
-                fragment = fragment.substring(0, lineNumberIndex);
-            }
-
-            writer.name("file").value(fragment);
-            writer.endObject();
         }
-        writer.endArray();
-        writer.endObject();
+        return BreadcrumbType.MANUAL;
+    }
+
+    private void configureRuntimeOptions(Client client, ReadableMap options) {
+        client.setIgnoreClasses("com.facebook.react.common.JavascriptException");
+        Configuration config = client.getConfig();
+        if (options.hasKey("appVersion")) {
+            String version = options.getString("appVersion");
+            if (version != null && version.length() > 0) {
+                client.setAppVersion(version);
+            }
+        }
+
+        String notify = null;
+        String sessions = null;
+
+        if (options.hasKey("endpoint")) {
+            notify = options.getString("endpoint");
+        }
+        if (options.hasKey("sessionsEndpoint")) {
+            sessions = options.getString("sessionsEndpoint");
+        }
+
+        if (notify != null && notify.length() > 0) {
+            config.setEndpoints(notify, sessions);
+        } else if (sessions != null && sessions.length() > 0) {
+            logger.warning("The session tracking endpoint should not be set "
+                    + "without the error reporting endpoint.");
+        }
+
+
+        if (options.hasKey("releaseStage")) {
+            String releaseStage = options.getString("releaseStage");
+            if (releaseStage != null && releaseStage.length() > 0) {
+                client.setReleaseStage(releaseStage);
+            }
+        }
+
+        if (options.hasKey("autoNotify")) {
+            if (options.getBoolean("autoNotify")) {
+                client.enableExceptionHandler();
+            } else {
+                client.disableExceptionHandler();
+            }
+        }
+
+        if (options.hasKey("codeBundleId")) {
+            String codeBundleId = options.getString("codeBundleId");
+            if (codeBundleId != null && codeBundleId.length() > 0) {
+                client.addToTab("app", "codeBundleId", codeBundleId);
+            }
+        }
+
+        if (options.hasKey("notifyReleaseStages")) {
+            ReadableArray stages = options.getArray("notifyReleaseStages");
+            if (stages != null && stages.size() > 0) {
+                String[] releaseStages = new String[stages.size()];
+                for (int i = 0; i < stages.size(); i++) {
+                    releaseStages[i] = stages.getString(i);
+                }
+                client.setNotifyReleaseStages(releaseStages);
+            }
+        }
+        if (options.hasKey("automaticallyCollectBreadcrumbs")) {
+            boolean autoCapture = options.getBoolean("automaticallyCollectBreadcrumbs");
+            config.setAutomaticallyCollectBreadcrumbs(autoCapture);
+        }
+        // Process session tracking last in case the effects of other options
+        // should be captured as a part of the session
+        if (options.hasKey("autoCaptureSessions")) {
+            boolean autoCapture = options.getBoolean("autoCaptureSessions");
+            config.setAutoCaptureSessions(autoCapture);
+            if (autoCapture) {
+                // The launch event session is skipped because autoCaptureSessions
+                // was not set when Bugsnag was first initialized. Manually sending a
+                // session to compensate.
+                client.resumeSession();
+            }
+        }
     }
 }

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
-@SuppressWarnings("JavadocMethod")
 public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
     private ReactContext reactContext;
@@ -33,6 +32,12 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
         return new BugsnagPackage();
     }
 
+    /**
+     * Instantiates a bugsnag client using the API key in the AndroidManifest.xml
+     *
+     * @param context the application context
+     * @return the bugsnag client
+     */
     public static Client start(Context context) {
         Client client = Bugsnag.init(context);
         // The first session starts during JS initialization
@@ -43,17 +48,34 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
         return client;
     }
 
+    /**
+     * Instantiates a bugsnag client with a given API key.
+     *
+     * @param context the application context
+     * @param apiKey the api key for your project
+     * @return the bugsnag client
+     */
     public static Client startWithApiKey(Context context, String apiKey) {
         Client client = Bugsnag.init(context, apiKey);
         client.setAutoCaptureSessions(false);
         return client;
     }
 
+    /**
+     * Instantiates a bugsnag client with a given configuration object.
+     *
+     * @param context the application context
+     * @param config configuration for how bugsnag should behave
+     * @return the bugsnag client
+     */
     public static Client startWithConfiguration(Context context, Configuration config) {
         config.setAutoCaptureSessions(false);
         return Bugsnag.init(context, config);
     }
 
+    /**
+     * Instantiates the bugsnag react native module
+     */
     public BugsnagReactNative(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
@@ -81,6 +103,12 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
         Bugsnag.resumeSession();
     }
 
+    /**
+     * Configures the bugsnag client with configuration options from the JS layer, starting a new 
+     * client if one has not already been created.
+     *
+     * @param options the JS configuration object
+     */
     @ReactMethod
     public void startWithOptions(ReadableMap options) {
         String apiKey = null;
@@ -96,7 +124,12 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
                 libraryVersion,
                 bugsnagAndroidVersion));
     }
-
+    
+    /**
+     * Leaves a breadcrumb from the JS layer.
+     *
+     * @param options the JS breadcrumb
+     */
     @ReactMethod
     public void leaveBreadcrumb(ReadableMap options) {
         String name = options.getString("name");
@@ -105,7 +138,13 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
                 readStringMap(options.getMap("metadata")));
     }
 
-
+    /**
+     * Notifies the native client that a JS error occurred. Upon invoking this method, an 
+     * error report will be generated and delivered via the native client.
+     *
+     * @param payload information about the JS error
+     * @param promise a nullable JS promise that is resolved after a report is delivered
+     */
     @ReactMethod
     public void notify(ReadableMap payload, Promise promise) {
         if (!payload.hasKey("errorClass")) {
@@ -144,6 +183,11 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
         }
     }
 
+    /**
+     * Sets a user from the JS layer.
+     *
+     * @param userInfo the JS user
+     */
     @ReactMethod
     public void setUser(ReadableMap userInfo) {
         String userId = userInfo.hasKey("id") ? userInfo.getString("id") : null;

--- a/android/src/main/java/com/bugsnag/DiagnosticsCallback.java
+++ b/android/src/main/java/com/bugsnag/DiagnosticsCallback.java
@@ -1,0 +1,124 @@
+package com.bugsnag;
+
+import com.bugsnag.android.Callback;
+import com.bugsnag.android.MetaData;
+import com.bugsnag.android.Report;
+import com.bugsnag.android.Severity;
+
+import android.support.annotation.NonNull;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Attaches report diagnostics before delivery
+ */
+class DiagnosticsCallback implements Callback {
+
+    static final String NOTIFIER_NAME = "Bugsnag for React Native";
+    static final String NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-react-native";
+
+    private final Severity severity;
+    private final String context;
+    private final String groupingHash;
+    private final Map<String, Object> metadata;
+    private final String libraryVersion;
+    private final String bugsnagAndroidVersion;
+
+    DiagnosticsCallback(String libraryVersion,
+                        String bugsnagAndroidVersion,
+                        ReadableMap payload) {
+        this.libraryVersion = libraryVersion;
+        this.bugsnagAndroidVersion = bugsnagAndroidVersion;
+        severity = parseSeverity(payload.getString("severity"));
+        metadata = readObjectMap(payload.getMap("metadata"));
+
+        if (payload.hasKey("context")) {
+            context = payload.getString("context");
+        } else {
+            context = null;
+        }
+
+        if (payload.hasKey("groupingHash")) {
+            groupingHash = payload.getString("groupingHash");
+        } else {
+            groupingHash = null;
+        }
+    }
+
+    Severity parseSeverity(String value) {
+        switch (value) {
+            case "error":
+                return Severity.ERROR;
+            case "info":
+                return Severity.INFO;
+            case "warning":
+            default:
+                return Severity.WARNING;
+        }
+    }
+
+    /**
+     * Convert a typed map from JS into a Map
+     */
+    Map<String, Object> readObjectMap(ReadableMap map) {
+        Map<String, Object> output = new HashMap<>();
+        ReadableMapKeySetIterator iterator = map.keySetIterator();
+
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            ReadableMap pair = map.getMap(key);
+            switch (pair.getString("type")) {
+                case "boolean":
+                    output.put(key, pair.getBoolean("value"));
+                    break;
+                case "number":
+                    output.put(key, pair.getDouble("value"));
+                    break;
+                case "string":
+                    output.put(key, pair.getString("value"));
+                    break;
+                case "map":
+                    output.put(key, readObjectMap(pair.getMap("value")));
+                    break;
+                default:
+                    break;
+            }
+        }
+        return output;
+    }
+
+    @Override
+    public void beforeNotify(@NonNull Report report) {
+        report.getNotifier().setName(NOTIFIER_NAME);
+        report.getNotifier().setURL(NOTIFIER_URL);
+        report.getNotifier().setVersion(String.format("%s (Android %s)",
+                libraryVersion,
+                bugsnagAndroidVersion));
+
+        if (groupingHash != null && groupingHash.length() > 0) {
+            report.getError().setGroupingHash(groupingHash);
+        }
+        if (context != null && context.length() > 0) {
+            report.getError().setContext(context);
+        }
+        if (metadata != null) {
+            MetaData reportMetadata = report.getError().getMetaData();
+            for (String tab : metadata.keySet()) {
+                Object value = metadata.get(tab);
+
+                if (value instanceof Map) {
+                    @SuppressWarnings("unchecked") // ignore type erasure when casting Map
+                            Map<String, Object> values = (Map<String, Object>) value;
+
+                    for (String key : values.keySet()) {
+                        reportMetadata.addToTab(tab, key, values.get(key));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/bugsnag/JavaScriptException.java
+++ b/android/src/main/java/com/bugsnag/JavaScriptException.java
@@ -1,0 +1,78 @@
+package com.bugsnag;
+
+import com.bugsnag.android.JsonStream;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+
+/**
+ * Creates a streamable exception with a JavaScript stacktrace
+ */
+class JavaScriptException extends Exception implements JsonStream.Streamable {
+
+    private static final String EXCEPTION_TYPE = "browserjs";
+    private static final long serialVersionUID = 1175784680140218622L;
+
+    private final String name;
+    private final String rawStacktrace;
+
+    JavaScriptException(String name, String message, String rawStacktrace) {
+        super(message);
+        this.name = name;
+        this.rawStacktrace = rawStacktrace;
+    }
+
+    @Override
+    public void toStream(@NonNull JsonStream writer) throws IOException {
+        writer.beginObject();
+        writer.name("errorClass").value(name);
+        writer.name("message").value(getLocalizedMessage());
+        writer.name("type").value(EXCEPTION_TYPE);
+
+        writer.name("stacktrace");
+        writer.beginArray();
+        for (String rawFrame : rawStacktrace.split("\\n")) {
+            writer.beginObject();
+            String[] methodComponents = rawFrame.split("@", 2);
+            String fragment = methodComponents[0];
+            if (methodComponents.length == 2) {
+                writer.name("method").value(methodComponents[0]);
+                fragment = methodComponents[1];
+            }
+
+            int columnIndex = fragment.lastIndexOf(":");
+            if (columnIndex != -1) {
+                String columnString = fragment.substring(columnIndex + 1);
+                try {
+                    int columnNumber = Integer.parseInt(columnString);
+                    writer.name("columnNumber").value(columnNumber);
+                } catch (NumberFormatException exc) {
+                    BugsnagReactNative.logger.info(String.format(
+                            "Failed to parse column: '%s'",
+                            columnString));
+                }
+                fragment = fragment.substring(0, columnIndex);
+            }
+
+            int lineNumberIndex = fragment.lastIndexOf(":");
+            if (lineNumberIndex != -1) {
+                String lineNumberString = fragment.substring(lineNumberIndex + 1);
+                try {
+                    int lineNumber = Integer.parseInt(lineNumberString);
+                    writer.name("lineNumber").value(lineNumber);
+                } catch (NumberFormatException exc) {
+                    BugsnagReactNative.logger.info(String.format(
+                            "Failed to parse lineNumber: '%s'",
+                            lineNumberString));
+                }
+                fragment = fragment.substring(0, lineNumberIndex);
+            }
+
+            writer.name("file").value(fragment);
+            writer.endObject();
+        }
+        writer.endArray();
+        writer.endObject();
+    }
+}

--- a/examples/plain/android/app/build.gradle
+++ b/examples/plain/android/app/build.gradle
@@ -131,6 +131,13 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    lintOptions {
+        abortOnError true
+        warningsAsErrors true
+        baseline file("lint-baseline.xml")
+    }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
@@ -162,4 +169,18 @@ task copyDownloadableDepsToLibs(type: Copy) {
 
 bugsnag {
     overwrite true
+}
+
+apply plugin: 'checkstyle'
+
+checkstyle {
+    toolVersion = "8.18"
+}
+
+task("checkstyle", type: Checkstyle) {
+    configFile rootProject.file("config/checkstyle/checkstyle.xml")
+    source  "src/"
+    include "**/*.java"
+    exclude "**/external/**/*.java"
+    classpath = files()
 }

--- a/examples/plain/android/app/lint-baseline.xml
+++ b/examples/plain/android/app/lint-baseline.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="4" by="lint 3.1.4">
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
+        errorLine1="        android:targetSdkVersion=&quot;22&quot; />"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="11"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.android.support:appcompat-v7 than 27.1.1 is available: 28.0.0"
+        errorLine1="    implementation &quot;com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="159"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="GradleDynamicVersion"
+        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (com.facebook.react:react-native:+)"
+        errorLine1="    implementation &quot;com.facebook.react:react-native:+&quot;  // From node_modules"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="160"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="GradleOverrides"
+        message="This `versionCode` value (`1`) is not used; it is always overridden by the value specified in the Gradle build script (`1`)"
+        errorLine1="    android:versionCode=&quot;1&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="3"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="GradleOverrides"
+        message="This `versionName` value (`1.0`) is not used; it is always overridden by the value specified in the Gradle build script (`1.0`)"
+        errorLine1="    android:versionName=&quot;1.0&quot;>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="4"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="GradleOverrides"
+        message="This `minSdkVersion` value (`16`) is not used; it is always overridden by the value specified in the Gradle build script (`16`)"
+        errorLine1="        android:minSdkVersion=&quot;16&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="10"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="GradleOverrides"
+        message="This `targetSdkVersion` value (`22`) is not used; it is always overridden by the value specified in the Gradle build script (`26`)"
+        errorLine1="        android:targetSdkVersion=&quot;22&quot; />"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="11"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="AllowBackup"
+        message="On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute `android:fullBackupContent` to specify an `@xml` resource which configures which files to backup. More info: https://developer.android.com/training/backup/autosyncapi.html"
+        errorLine1="    &lt;application"
+        errorLine2="    ^">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="13"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.mipmap.ic_launcher_round` appears to be unused">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher_round.png"/>
+        <location
+            file="src/main/res/mipmap-mdpi/ic_launcher_round.png"/>
+        <location
+            file="src/main/res/mipmap-xhdpi/ic_launcher_round.png"/>
+        <location
+            file="src/main/res/mipmap-xxhdpi/ic_launcher_round.png"/>
+        <location
+            file="src/main/res/mipmap-xxxhdpi/ic_launcher_round.png"/>
+    </issue>
+
+    <issue
+        id="GoogleAppIndexingWarning"
+        message="App is not indexable by Google Search; consider adding at least one Activity with an ACTION-VIEW intent filter. See issue explanation for more details."
+        errorLine1="    &lt;application"
+        errorLine2="    ^">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="13"
+            column="5"/>
+    </issue>
+
+</issues>

--- a/examples/plain/android/app/src/main/java/com/bugsnagreactnativeexample/CrashyModule.java
+++ b/examples/plain/android/app/src/main/java/com/bugsnagreactnativeexample/CrashyModule.java
@@ -5,17 +5,17 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
 public class CrashyModule extends ReactContextBaseJavaModule {
-  public CrashyModule(ReactApplicationContext reactContext) {
-    super(reactContext);
-  }
+    public CrashyModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
 
-  @Override
-  public String getName() {
-    return "CrashyCrashy";
-  }
+    @Override
+    public String getName() {
+        return "CrashyCrashy";
+    }
 
-  @ReactMethod
-  public void generateCrash() throws Exception {
-    throw new Exception("Ooopsy from Java!");
-  }
+    @ReactMethod
+    public void generateCrash() throws Exception {
+        throw new Exception("Ooopsy from Java!");
+    }
 }

--- a/examples/plain/android/app/src/main/java/com/bugsnagreactnativeexample/CrashyPackage.java
+++ b/examples/plain/android/app/src/main/java/com/bugsnagreactnativeexample/CrashyPackage.java
@@ -12,22 +12,22 @@ import java.util.List;
 
 class CrashyPackage implements ReactPackage {
 
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
 
-  @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
-  @Override
-  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Collections.emptyList();
-  }
+    @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
 
-  @Override
-  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    List<NativeModule> modules = new ArrayList<>();
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
 
-    modules.add(new CrashyModule(reactContext));
+        modules.add(new CrashyModule(reactContext));
 
-    return modules;
-  }
+        return modules;
+    }
 }

--- a/examples/plain/android/app/src/main/java/com/bugsnagreactnativeexample/MainApplication.java
+++ b/examples/plain/android/app/src/main/java/com/bugsnagreactnativeexample/MainApplication.java
@@ -1,11 +1,10 @@
 package com.bugsnagreactnativeexample;
 
+import com.bugsnag.BugsnagReactNative;
+
 import android.app.Application;
-import android.util.Log;
 
 import com.facebook.react.ReactApplication;
-import com.bugsnag.BugsnagReactNative;
-import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -16,36 +15,36 @@ import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
 
-  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+    private final ReactNativeHost reactNativeHost = new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+            return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+            return Arrays.asList(
+                    new MainReactPackage(),
+                    new CrashyPackage(),
+                    BugsnagReactNative.getPackage()
+            );
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+            return "index";
+        }
+    };
+
     @Override
-    public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
+    public ReactNativeHost getReactNativeHost() {
+        return reactNativeHost;
     }
 
     @Override
-    protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new CrashyPackage(),
-          BugsnagReactNative.getPackage()
-      );
+    public void onCreate() {
+        super.onCreate();
+        BugsnagReactNative.start(this);
+        SoLoader.init(this, /* native exopackage */ false);
     }
-
-    @Override
-    protected String getJSMainModuleName() {
-      return "index";
-    }
-  };
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    return mReactNativeHost;
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    BugsnagReactNative.start(this);
-    SoLoader.init(this, /* native exopackage */ false);
-  }
 }

--- a/examples/plain/android/config/checkstyle/checkstyle.xml
+++ b/examples/plain/android/config/checkstyle/checkstyle.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="FileTabCharacter">
+            <property name="eachLine" value="true"/>
+        </module>
+
+    <module name="SuppressWarningsFilter" />
+    <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="4"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="specialImportsRegExp" value="com.bugsnag"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>

--- a/examples/plain/android/config/checkstyle/checkstyle.xml
+++ b/examples/plain/android/config/checkstyle/checkstyle.xml
@@ -25,9 +25,14 @@
             <property name="eachLine" value="true"/>
         </module>
 
+    <module name="SuppressionFilter">
+        <property name="file" value="config/checkstyle/suppressions.xml"/>
+    </module>
     <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder" />
+
+
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/examples/plain/android/config/checkstyle/suppressions.xml
+++ b/examples/plain/android/config/checkstyle/suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <!-- react-native link adds an import in the wrong place on CI builds, this warning
+  is suppressed to avoid failing the build -->
+  <suppress checks="CustomImportOrder"
+            files="MainApplication.java"/>
+</suppressions>


### PR DESCRIPTION
## Goal

Code in bugsnag-react-native did not run checkstyle or Android Lint automatically, which would have helped detect code smells and generally improve code quality. Running these tools on CI should catch issues early and prevent us from shipping violations.

## Changeset

- Setup Android Lint to abort the build on any errors not included within a baseline of ignored issues, in the example project and Android code
- Setup Checkstyle to abort the build on any style errors in the example project and Android code
- Pre-existing violations were also addressed, including:

  - Splitting top-level classes into separate files
  - Using an indent of 4 rather than 2
  - Adding missing braces to conditionals
  - Adding default branch to switch statements
  - Ordering imports
  - Adding missing override modifiers
  - Fixing modifier ordering


## Tests

- Ran the new inspections both locally and on CI
- Ran mazerunner scenarios for Android
