### PR TITLE
Specify right dir for public headers to fix CocoaPods

### DIFF
--- a/BugsnagReactNative.podspec
+++ b/BugsnagReactNative.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source_files = 'cocoa/BugsnagReactNative.{h,m}',
                    'cocoa/vendor/bugsnag-cocoa/Source/**/*.{h,m,mm,cpp,c}',
 
-  s.public_header_files = 'cocoa/**/{Bugsnag,BugsnagReactNative,BugsnagMetaData,BugsnagConfiguration,BugsnagBreadcrumb,BugsnagCrashReport,BSG_KSCrashReportWriter}.h'
+  s.public_header_files = 'cocoa/vendor/bugsnag-cocoa/Source/**/{Bugsnag,BugsnagReactNative,BugsnagMetaData,BugsnagConfiguration,BugsnagBreadcrumb,BugsnagCrashReport,BSG_KSCrashReportWriter}.h'
 
   # If Bugsnag is previously installed via CocoaPods, use the Core subspec.
   s.subspec 'Core' do |core|


### PR DESCRIPTION
## Goal

Build fails when using CocoaPods because there are duplicate headers being added by CocoaPods because the directory was not specific enough.

<img width="934" alt="Screen Shot 2019-04-23 at 11 46 12 AM" src="https://user-images.githubusercontent.com/7799267/56603685-6a68fb00-65bd-11e9-906c-be8c4776635f.png">

## Tests

Tested locally editing my `BugsnagReactNative.podspec` file and running a `pod install` and then building

