### PR TITLE
Collect version information in device.runtimeVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 2.X.X (TBD)
+
+* Collect version information in device.runtimeVersions
+[#345](https://github.com/bugsnag/bugsnag-react-native/pull/345)
+
 ## 2.16.0 (2019-04-04)
 
 * (Android) Upgrade to bugsnag-android v4.13.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,6 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.13.0'
+    compile 'com.bugsnag:bugsnag-android:4.14.0'
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -9,6 +9,7 @@ import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Callback;
 import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
+import com.bugsnag.android.InternalHooks;
 import com.bugsnag.android.JsonStream;
 import com.bugsnag.android.MetaData;
 import com.bugsnag.android.Report;
@@ -104,6 +105,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
       libraryVersion = options.getString("version");
       bugsnagAndroidVersion = client.getClass().getPackage().getSpecificationVersion();
       configureRuntimeOptions(client, options);
+      InternalHooks.configureClient(client);
 
       logger.info(String.format("Initialized Bugsnag React Native %s/Android %s",
                   libraryVersion,

--- a/android/src/main/java/com/bugsnag/RuntimeVersions.java
+++ b/android/src/main/java/com/bugsnag/RuntimeVersions.java
@@ -1,0 +1,52 @@
+package com.bugsnag;
+
+import com.facebook.react.modules.systeminfo.ReactNativeVersion;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RuntimeVersions {
+
+  public static void addRuntimeVersions(Map<String, Object> device) {
+    @SuppressWarnings("unchecked") // ignore type erasure when casting Map
+    Map<String, Object> runtimeVersions = (Map<String, Object>) device.get("runtimeVersions");
+
+    if (runtimeVersions == null) {
+        runtimeVersions = new HashMap<String, Object>();
+        device.put("runtimeVersions", runtimeVersions);
+    }
+    runtimeVersions.put("reactNative", findReactNativeVersion());
+  }
+
+  // see https://github.com/facebook/react-native/blob/6df2edeb2a33d529e4b13a5b6767f300d08aeb0a/scripts/bump-oss-version.js
+  private static String findReactNativeVersion() {
+    String major = getStringSafe("major", ReactNativeVersion.VERSION);
+    String minor = getStringSafe("minor", ReactNativeVersion.VERSION);
+    String patch = getStringSafe("patch", ReactNativeVersion.VERSION);
+    String prerelease = getStringSafe("prerelease", ReactNativeVersion.VERSION);
+    StringBuilder sb = new StringBuilder();
+
+    if (major != null) {
+        sb.append(major);
+        sb.append(".");
+    }
+    if (minor != null) {
+        sb.append(minor);
+        sb.append(".");
+    }
+    if (patch != null) {
+        sb.append(patch);
+    }
+    if (prerelease != null) {
+        sb.append("-");
+        sb.append(prerelease);
+    }
+    return sb.toString();
+  }
+
+  private static String getStringSafe(String key, Map<String, Object> map) {
+    Object obj = map.get(key);
+    return (obj != null) ? obj.toString() : null;
+  }
+}

--- a/android/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/android/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -1,0 +1,26 @@
+package com.bugsnag.android;
+
+import com.bugsnag.RuntimeVersions;
+
+public class InternalHooks {
+
+  /**
+   * Configures the bugsnag client by hooking into package-visible APIs within bugsnag-android
+   */
+  public static void configureClient(Client client) {
+    client.getConfig().addBeforeSendSession(new BeforeSendSession() {
+      @Override
+      public void beforeSendSession(SessionTrackingPayload payload) {
+        RuntimeVersions.addRuntimeVersions(payload.getDevice());
+      }
+    });
+
+    client.getConfig().beforeSend(new BeforeSend() {
+      @Override
+      public boolean run(Report report) {
+        RuntimeVersions.addRuntimeVersions(report.getError().getDeviceData());
+        return true;
+      }
+    });
+  }
+}

--- a/cocoa/BugsnagReactNative.m
+++ b/cocoa/BugsnagReactNative.m
@@ -342,29 +342,34 @@ RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *)options) {
 
 // see https://github.com/facebook/react-native/blob/6df2edeb2a33d529e4b13a5b6767f300d08aeb0a/scripts/bump-oss-version.js
 - (NSString *)findReactNativeVersion {
-    NSDictionary *versionMap = RCTGetReactNativeVersion();
-    NSNumber *major = versionMap[@"major"];
-    NSNumber *minor = versionMap[@"minor"];
-    NSNumber *patch = versionMap[@"patch"];
-    NSString *prerelease = versionMap[@"prerelease"];
-    NSMutableString *versionString = [NSMutableString new];
+    static dispatch_once_t onceToken;
+    static NSString *BSGReactNativeVersion = nil;
+    dispatch_once(&onceToken, ^{
+        NSDictionary *versionMap = RCTGetReactNativeVersion();
+        NSNumber *major = versionMap[@"major"];
+        NSNumber *minor = versionMap[@"minor"];
+        NSNumber *patch = versionMap[@"patch"];
+        NSString *prerelease = versionMap[@"prerelease"];
+        NSMutableString *versionString = [NSMutableString new];
 
-    if (![major isEqual:[NSNull null]]) {
-        [versionString appendString:[major stringValue]];
-        [versionString appendString:@"."];
-    }
-    if (![minor isEqual:[NSNull null]]) {
-        [versionString appendString:[minor stringValue]];
-        [versionString appendString:@"."];
-    }
-    if (![patch isEqual:[NSNull null]]) {
-        [versionString appendString:[patch stringValue]];
-    }
-    if (![prerelease isEqual:[NSNull null]]) {
-        [versionString appendString:@"-"];
-        [versionString appendString:prerelease];
-    }
-    return [NSString stringWithString:versionString];
+        if (![major isEqual:[NSNull null]]) {
+            [versionString appendString:[major stringValue]];
+            [versionString appendString:@"."];
+        }
+        if (![minor isEqual:[NSNull null]]) {
+            [versionString appendString:[minor stringValue]];
+            [versionString appendString:@"."];
+        }
+        if (![patch isEqual:[NSNull null]]) {
+            [versionString appendString:[patch stringValue]];
+        }
+        if (![prerelease isEqual:[NSNull null]]) {
+            [versionString appendString:@"-"];
+            [versionString appendString:prerelease];
+        }
+        BSGReactNativeVersion = [NSString stringWithString:versionString];
+    });
+    return BSGReactNativeVersion;
 }
 
 - (void)setNotifierDetails:(NSString *)packageVersion {

--- a/cocoa/vendor/bugsnag-cocoa/Source/BSGOutOfMemoryWatchdog.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BSGOutOfMemoryWatchdog.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+
+@class BugsnagConfiguration;
+
+@interface BSGOutOfMemoryWatchdog : NSObject
+
+@property(nonatomic, strong, readonly) NSDictionary *lastBootCachedFileInfo;
+
+/**
+ * Create a new watchdog using the sentinel path to store app/device state
+ */
+- (instancetype)initWithSentinelPath:(NSString *)sentinelFilePath
+                       configuration:(BugsnagConfiguration *)config NS_DESIGNATED_INITIALIZER;
+/**
+ * @return YES if the app was killed to end the previous app launch
+ */
+- (BOOL)didOOMLastLaunch;
+/**
+ * Begin monitoring for lifecycle events and report the OOM from the last launch (if any)
+ */
+- (void)enable;
+/**
+ * Stop monitoring for lifecycle events
+ */
+- (void)disable;
+@end

--- a/cocoa/vendor/bugsnag-cocoa/Source/BSGOutOfMemoryWatchdog.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BSGOutOfMemoryWatchdog.m
@@ -1,0 +1,243 @@
+#if (TARGET_OS_TV || TARGET_OS_IPHONE)
+#define BSGOOMAvailable 1
+#else
+#define BSGOOMAvailable 0
+#endif
+
+#if BSGOOMAvailable
+#import <UIKit/UIKit.h>
+#endif
+#import "BSGOutOfMemoryWatchdog.h"
+#import "BSG_KSSystemInfo.h"
+#import "BugsnagLogger.h"
+#import "Bugsnag.h"
+#import "BugsnagKSCrashSysInfoParser.h"
+#import "BugsnagSessionTracker.h"
+
+@interface BSGOutOfMemoryWatchdog ()
+@property(nonatomic, getter=isWatching) BOOL watching;
+@property(nonatomic, strong) NSString *sentinelFilePath;
+@property(nonatomic, getter=didOOMLastLaunch) BOOL oomLastLaunch;
+@property(nonatomic, strong, readwrite) NSMutableDictionary *cachedFileInfo;
+@property(nonatomic, strong, readwrite) NSDictionary *lastBootCachedFileInfo;
+@end
+
+@implementation BSGOutOfMemoryWatchdog
+
+- (instancetype)init {
+    self = [self initWithSentinelPath:nil configuration:nil];
+    return self;
+}
+
+- (instancetype)initWithSentinelPath:(NSString *)sentinelFilePath
+                       configuration:(BugsnagConfiguration *)config {
+    if (sentinelFilePath.length == 0) {
+        return nil; // disallow enabling a watcher without a file path
+    }
+    if (self = [super init]) {
+        _sentinelFilePath = sentinelFilePath;
+#ifdef BSGOOMAvailable
+        _oomLastLaunch = [self computeDidOOMLastLaunchWithConfig:config];
+        _cachedFileInfo = [self generateCacheInfoWithConfig:config];
+#endif
+    }
+    return self;
+}
+
+- (void)enable {
+#if BSGOOMAvailable
+    if ([self isWatching]) {
+        return;
+    }
+    [self writeSentinelFile];
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self
+               selector:@selector(disable:)
+                   name:UIApplicationWillTerminateNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleTransitionToBackground:)
+                   name:UIApplicationDidEnterBackgroundNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleTransitionToForeground:)
+                   name:UIApplicationWillEnterForegroundNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleLowMemoryChange:)
+                   name:UIApplicationDidReceiveMemoryWarningNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleUpdateSession:)
+                   name:BSGSessionUpdateNotification
+                 object:nil];
+    [[Bugsnag configuration]
+        addObserver:self
+         forKeyPath:NSStringFromSelector(@selector(releaseStage))
+            options:NSKeyValueObservingOptionNew
+            context:nil];
+    self.watching = YES;
+#endif
+}
+
+- (void)disable:(NSNotification *)note {
+    [self disable];
+}
+
+- (void)disable {
+    if (![self isWatching]) {
+        // Avoid unsubscribing from KVO when not observing
+        // From the docs:
+        // > Asking to be removed as an observer if not already registered as
+        // > one results in an NSRangeException. You either call
+        // > `removeObserver:forKeyPath:context: exactly once for the
+        // > corresponding call to `addObserver:forKeyPath:options:context:`
+        return;
+    }
+    self.watching = NO;
+    [self deleteSentinelFile];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    @try {
+        [[Bugsnag configuration]
+            removeObserver:self
+                forKeyPath:NSStringFromSelector(@selector(releaseStage))];
+    } @catch (NSException *exception) {
+        // Shouldn't happen, but if for some reason, unregistration happens
+        // without registration, catch the resulting exception.
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSString *, id> *)change
+                       context:(void *)context {
+    self.cachedFileInfo[@"app"][@"releaseStage"] = change[NSKeyValueChangeNewKey];
+    [self writeSentinelFile];
+}
+- (void)handleTransitionToForeground:(NSNotification *)note {
+    self.cachedFileInfo[@"app"][@"inForeground"] = @YES;
+    [self writeSentinelFile];
+}
+
+- (void)handleTransitionToBackground:(NSNotification *)note {
+    self.cachedFileInfo[@"app"][@"inForeground"] = @NO;
+    [self writeSentinelFile];
+}
+
+- (void)handleLowMemoryChange:(NSNotification *)note {
+    self.cachedFileInfo[@"device"][@"lowMemory"] = [[Bugsnag payloadDateFormatter]
+                                                    stringFromDate:[NSDate date]];
+    [self writeSentinelFile];
+}
+
+- (void)handleUpdateSession:(NSNotification *)note {
+    id session = [note object];
+    NSMutableDictionary *cache = (id)self.cachedFileInfo;
+    if (session) {
+        cache[@"session"] = session;
+    } else {
+        [cache removeObjectForKey:@"session"];
+    }
+    [self writeSentinelFile];
+}
+
+- (BOOL)computeDidOOMLastLaunchWithConfig:(BugsnagConfiguration *)config {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:self.sentinelFilePath]) {
+        NSDictionary *lastBootInfo = [self readSentinelFile];
+        if (lastBootInfo != nil) {
+            self.lastBootCachedFileInfo = lastBootInfo;
+            NSString *lastBootAppVersion =
+                [lastBootInfo valueForKeyPath:@"app.version"];
+            NSString *lastBootOSVersion =
+                [lastBootInfo valueForKeyPath:@"device.osBuild"];
+            BOOL lastBootInForeground =
+                [[lastBootInfo valueForKeyPath:@"app.inForeground"] boolValue];
+            NSString *osVersion = [BSG_KSSystemInfo osBuildVersion];
+            NSDictionary *appInfo = [[NSBundle mainBundle] infoDictionary];
+            NSString *appVersion =
+                [appInfo valueForKey:(__bridge NSString *)kCFBundleVersionKey];
+            BOOL sameVersions = [lastBootOSVersion isEqualToString:osVersion] &&
+                                [lastBootAppVersion isEqualToString:appVersion];
+            BOOL shouldReport = config.reportBackgroundOOMs || lastBootInForeground;
+            [self deleteSentinelFile];
+            return sameVersions && shouldReport;
+        }
+    }
+    return NO;
+}
+
+- (void)deleteSentinelFile {
+    NSError *error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:self.sentinelFilePath
+                                               error:&error];
+    if (error) {
+        bsg_log_err(@"Failed to delete oom watchdog file: %@", error);
+        unlink([self.sentinelFilePath UTF8String]);
+    }
+}
+
+- (NSDictionary *)readSentinelFile {
+    NSError *error = nil;
+    NSData *data = [NSData dataWithContentsOfFile:self.sentinelFilePath options:0 error:&error];
+    if (error) {
+        bsg_log_err(@"Failed to read oom watchdog file: %@", error);
+        return nil;
+    }
+    NSDictionary *contents = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    if (error) {
+        bsg_log_err(@"Failed to read oom watchdog file: %@", error);
+        return nil;
+    }
+    return contents;
+}
+
+
+- (void)writeSentinelFile {
+    NSError *error = nil;
+    if (![NSJSONSerialization isValidJSONObject:self.cachedFileInfo]) {
+        bsg_log_err(@"Cached oom watchdog data cannot be written as JSON");
+        return;
+    }
+    NSData *data = [NSJSONSerialization dataWithJSONObject:self.cachedFileInfo options:0 error:&error];
+    if (error) {
+        bsg_log_err(@"Cached oom watchdog data cannot be written as JSON: %@", error);
+        return;
+    }
+    [data writeToFile:self.sentinelFilePath atomically:YES];
+}
+
+- (NSMutableDictionary *)generateCacheInfoWithConfig:(BugsnagConfiguration *)config {
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    NSMutableDictionary *cache = [NSMutableDictionary new];
+    NSMutableDictionary *app = [NSMutableDictionary new];
+
+    app[@"id"] = systemInfo[@BSG_KSSystemField_BundleID] ?: @"";
+    app[@"name"] = systemInfo[@BSG_KSSystemField_BundleName] ?: @"";
+    app[@"releaseStage"] = config.releaseStage;
+    app[@"version"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
+    app[@"inForeground"] = @YES;
+#if TARGET_OS_TV
+    app[@"type"] = @"tvOS";
+#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    app[@"type"] = @"iOS";
+#endif
+    cache[@"app"] = app;
+
+    NSMutableDictionary *device = [NSMutableDictionary new];
+    device[@"id"] = systemInfo[@BSG_KSSystemField_DeviceAppHash];
+    // device[@"lowMemory"] is initially unset
+    device[@"osBuild"] = systemInfo[@BSG_KSSystemField_OSVersion];
+    device[@"osVersion"] = systemInfo[@BSG_KSSystemField_SystemVersion];
+    device[@"model"] = systemInfo[@BSG_KSSystemField_Machine];
+    device[@"wordSize"] = @(PLATFORM_WORD_SIZE);
+#if TARGET_OS_SIMULATOR
+    device[@"simulator"] = @YES;
+#else
+    device[@"simulator"] = @NO;
+#endif
+    cache[@"device"] = device;
+
+    return cache;
+}
+
+@end

--- a/cocoa/vendor/bugsnag-cocoa/Source/Bugsnag.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/Bugsnag.h
@@ -67,6 +67,11 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)startBugsnagWithConfiguration:
     (BugsnagConfiguration *_Nonnull)configuration;
 
+/**
+ * @return YES if Bugsnag has been started and the previous launch crashed
+ */
++ (BOOL)appDidCrashLastLaunch;
+
 /** Send a custom or caught exception to Bugsnag.
  *
  * The exception will be sent to Bugsnag in the background allowing your

--- a/cocoa/vendor/bugsnag-cocoa/Source/Bugsnag.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/Bugsnag.m
@@ -76,6 +76,13 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
     return bsg_g_bugsnag_notifier;
 }
 
++ (BOOL)appDidCrashLastLaunch {
+    if ([self bugsnagStarted]) {
+        return [self.notifier appCrashedLastLaunch];
+    }
+    return NO;
+}
+
 + (void)notify:(NSException *)exception {
     if ([self bugsnagStarted]) {
         [self.notifier notifyException:exception

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagBreadcrumb.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagBreadcrumb.h
@@ -94,6 +94,10 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
 /** Number of breadcrumbs accumulated */
 @property(assign, readonly) NSUInteger count;
+/**
+ * Path where breadcrumbs are persisted on disk
+ */
+@property (nonatomic, readonly, strong, nullable) NSString *cachePath;
 
 /**
  * Store a new breadcrumb with a provided message.
@@ -124,5 +128,10 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
  * returns nil if empty
  */
 - (NSArray *_Nullable)arrayValue;
+
+/**
+ * Reads and return breadcrumb data currently stored on disk
+ */
+- (NSDictionary *_Nullable)cachedBreadcrumbs;
 
 @end

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagConfiguration.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagConfiguration.h
@@ -57,6 +57,13 @@ typedef bool (^BugsnagBeforeSendBlock)(NSDictionary *_Nonnull rawEventData,
                                        BugsnagCrashReport *_Nonnull reports);
 
 /**
+ * A configuration block for modifying a session. Intended for internal usage only.
+ *
+ * @param sessionPayload The session about to be delivered
+ */
+typedef void(^BeforeSendSession)(NSMutableDictionary *_Nonnull sessionPayload);
+
+/**
  *  A handler for modifying data before sending it to Bugsnag
  *
  *  @param rawEventReports The raw event data written at crash time. This
@@ -126,6 +133,13 @@ BugsnagBreadcrumbs *breadcrumbs;
  */
 @property(readonly, strong, nullable)
     NSArray<BugsnagBeforeSendBlock> *beforeSendBlocks;
+
+/**
+ *  Hooks for modifying sessions before they are sent to Bugsnag. Intended for internal use only by React Native/Unity.
+ */
+@property(readonly, strong, nullable)
+NSArray<BeforeSendSession> *beforeSendSessionBlocks;
+
 /**
  *  Optional handler invoked when a crash or fatal signal occurs
  */
@@ -143,6 +157,12 @@ BugsnagBreadcrumbs *breadcrumbs;
  * will be captured.
  */
 @property BOOL shouldAutoCaptureSessions;
+
+/**
+ * Whether the app should report out of memory events which terminate the app
+ * while the app is in the background.
+ */
+@property BOOL reportBackgroundOOMs;
 
 /**
  * Retrieves the endpoint used to notify Bugsnag of errors
@@ -198,6 +218,13 @@ BugsnagBreadcrumbs *breadcrumbs;
  *  @param block A block which returns YES if the report should be sent
  */
 - (void)addBeforeSendBlock:(BugsnagBeforeSendBlock _Nonnull)block;
+
+/**
+ *  Add a callback to be invoked before a session is sent to Bugsnag. Intended for internal usage only.
+ *
+ *  @param block A block which can modify the session
+ */
+- (void)addBeforeSendSession:(BeforeSendSession _Nonnull)block;
 
 /**
  * Clear all callbacks

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagConfiguration.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagConfiguration.m
@@ -48,6 +48,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableArray *beforeNotifyHooks;
 @property(nonatomic, readwrite, strong) NSMutableArray *beforeSendBlocks;
+@property(nonatomic, readwrite, strong) NSMutableArray *beforeSendSessionBlocks;
 @end
 
 @implementation BugsnagConfiguration
@@ -62,10 +63,12 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
         _beforeNotifyHooks = [NSMutableArray new];
         _beforeSendBlocks = [NSMutableArray new];
+        _beforeSendSessionBlocks = [NSMutableArray new];
         _notifyReleaseStages = nil;
         _breadcrumbs = [BugsnagBreadcrumbs new];
         _automaticallyCollectBreadcrumbs = YES;
         _shouldAutoCaptureSessions = YES;
+        _reportBackgroundOOMs = YES;
 
         if ([NSURLSession class]) {
             _session = [NSURLSession
@@ -105,6 +108,10 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
     [(NSMutableArray *)self.beforeSendBlocks addObject:[block copy]];
 }
 
+- (void)addBeforeSendSession:(BeforeSendSession)block {
+    [(NSMutableArray *)self.beforeSendSessionBlocks addObject:[block copy]];
+}
+
 - (void)clearBeforeSendBlocks {
     [(NSMutableArray *)self.beforeSendBlocks removeAllObjects];
 }
@@ -123,7 +130,10 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 
 - (void)setReleaseStage:(NSString *)newReleaseStage {
     @synchronized (self) {
+        NSString *key = NSStringFromSelector(@selector(releaseStage));
+        [self willChangeValueForKey:key];
         _releaseStage = newReleaseStage;
+        [self didChangeValueForKey:key];
         [self.config addAttribute:BSGKeyReleaseStage
                         withValue:newReleaseStage
                     toTabWithName:BSGKeyConfig];

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagHandledState.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagHandledState.h
@@ -17,7 +17,8 @@ typedef NS_ENUM(NSUInteger, SeverityReasonType) {
     UserSpecifiedSeverity,
     UserCallbackSetSeverity,
     PromiseRejection,
-    LogMessage
+    LogMessage,
+    LikelyOutOfMemory,
 };
 
 @interface BugsnagHandledState : NSObject

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagHandledState.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagHandledState.m
@@ -19,6 +19,7 @@ static NSString *const kUnhandledException = @"unhandledException";
 static NSString *const kSignal = @"signal";
 static NSString *const kPromiseRejection = @"unhandledPromiseRejection";
 static NSString *const kHandledError = @"handledError";
+static NSString *const kLikelyOutOfMemory = @"outOfMemory";
 static NSString *const kLogGenerated = @"log";
 static NSString *const kHandledException = @"handledException";
 static NSString *const kUserSpecifiedSeverity = @"userSpecifiedSeverity";
@@ -58,6 +59,7 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
     case UserSpecifiedSeverity:
     case UserCallbackSetSeverity:
         break;
+    case LikelyOutOfMemory:
     case UnhandledException:
         severity = BSGSeverityError;
         unhandled = YES;
@@ -127,6 +129,8 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
         return kLogGenerated;
     case UnhandledException:
         return kUnhandledException;
+    case LikelyOutOfMemory:
+        return kLikelyOutOfMemory;
     }
 }
 
@@ -147,6 +151,8 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
         return UserCallbackSetSeverity;
     } else if ([kPromiseRejection isEqualToString:string]) {
         return PromiseRejection;
+    } else if ([kLikelyOutOfMemory isEqualToString:string]) {
+        return LikelyOutOfMemory;
     } else {
         return UnhandledException;
     }

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#define PLATFORM_WORD_SIZE sizeof(void*)*8
+
 NSDictionary *_Nonnull BSGParseDevice(NSDictionary *_Nonnull report);
 NSDictionary *_Nonnull BSGParseApp(NSDictionary *_Nonnull report);
 NSDictionary *_Nonnull BSGParseAppState(NSDictionary *_Nonnull report, NSString *_Nullable preferredVersion);

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.m
@@ -119,11 +119,10 @@ NSDictionary *BSGParseDeviceState(NSDictionary *report) {
     BSGDictSetSafeObject(deviceState, report[@"system_name"], @"osName");
     BSGDictSetSafeObject(deviceState, report[@"system_version"], @"osVersion");
 
-    NSString *osVersion = report[@"os_version"];
-
-    if (osVersion != nil) {
-        BSGDictSetSafeObject(deviceState, @{@"osBuild": osVersion}, @"runtimeVersions");
-    }
+    NSMutableDictionary *runtimeVersions = [NSMutableDictionary new];
+    BSGDictSetSafeObject(runtimeVersions, report[@"os_version"], @"osBuild");
+    BSGDictSetSafeObject(runtimeVersions, report[@"clang_version"], @"clangVersion");
+    BSGDictSetSafeObject(deviceState, runtimeVersions, @"runtimeVersions");
 
     BSGDictSetSafeObject(deviceState, @(PLATFORM_WORD_SIZE), @"wordSize");
     BSGDictSetSafeObject(deviceState, @"Apple", @"manufacturer");

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.m
@@ -13,8 +13,6 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagLogger.h"
 
-#define PLATFORM_WORD_SIZE sizeof(void*)*8
-
 NSDictionary *BSGParseDevice(NSDictionary *report) {
     NSMutableDictionary *device = [NSMutableDictionary new];
     NSDictionary *state = [report valueForKeyPath:@"user.state.deviceState"];
@@ -120,7 +118,13 @@ NSDictionary *BSGParseDeviceState(NSDictionary *report) {
     BSGDictSetSafeObject(deviceState, report[@"machine"], @"model");
     BSGDictSetSafeObject(deviceState, report[@"system_name"], @"osName");
     BSGDictSetSafeObject(deviceState, report[@"system_version"], @"osVersion");
-    BSGDictSetSafeObject(deviceState, report[@"os_version"], @"osBuild");
+
+    NSString *osVersion = report[@"os_version"];
+
+    if (osVersion != nil) {
+        BSGDictSetSafeObject(deviceState, @{@"osBuild": osVersion}, @"runtimeVersions");
+    }
+
     BSGDictSetSafeObject(deviceState, @(PLATFORM_WORD_SIZE), @"wordSize");
     BSGDictSetSafeObject(deviceState, @"Apple", @"manufacturer");
     BSGDictSetSafeObject(deviceState, report[@"jailbroken"], @"jailbroken");

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.h
@@ -51,6 +51,8 @@
 - (void)stopSession;
 - (BOOL)resumeSession;
 
+- (BOOL)appCrashedLastLaunch;
+
 /**
  *  Notify Bugsnag of an exception
  *

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
@@ -32,8 +32,11 @@
 #import "BugsnagLogger.h"
 #import "BugsnagKeys.h"
 #import "BugsnagSessionTracker.h"
+#import "BSGOutOfMemoryWatchdog.h"
 #import "BSG_RFC3339DateTool.h"
 #import "BSG_KSCrashType.h"
+#import "BSG_KSCrashState.h"
+#import "BSG_KSMach.h"
 
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -72,6 +75,8 @@ static NSDictionary *notificationNameMap;
 
 static char *sessionId[128];
 static char *sessionStartDate[128];
+static char *watchdogSentinelPath = NULL;
+static char *crashSentinelPath = NULL;
 static NSUInteger handledCount;
 static bool hasRecordedSessions;
 
@@ -99,6 +104,19 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
         }
         if (bsg_g_bugsnag_data.metaDataJSON) {
             writer->addJSONElement(writer, "metaData", bsg_g_bugsnag_data.metaDataJSON);
+        }
+        if (watchdogSentinelPath != NULL) {
+            // Delete the file to indicate a handled termination
+            unlink(watchdogSentinelPath);
+        }
+        if (crashSentinelPath != NULL) {
+            // Create a file to indicate that the crash has been handled by
+            // the library. This exists in case the subsequent `onCrash` handler
+            // crashes or otherwise corrupts the crash report file.
+            int fd = open(crashSentinelPath, O_RDWR | O_CREAT, 0644);
+            if (fd > -1) {
+                close(fd);
+            }
         }
     }
 
@@ -180,6 +198,8 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property(nonatomic) BugsnagCrashSentry *crashSentry;
 @property(nonatomic) BugsnagErrorReportApiClient *errorReportApiClient;
 @property(nonatomic, readwrite) BugsnagSessionTracker *sessionTracker;
+@property (nonatomic, strong) BSGOutOfMemoryWatchdog *oomWatchdog;
+@property (nonatomic) BOOL appCrashedLastLaunch;
 @end
 
 @implementation BugsnagNotifier
@@ -187,6 +207,8 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @synthesize configuration;
 
 - (id)initWithConfiguration:(BugsnagConfiguration *)initConfiguration {
+    static NSString *const BSGWatchdogSentinelFileName = @"bugsnag_oom_watchdog.json";
+    static NSString *const BSGCrashSentinelFileName = @"bugsnag_handled_crash.txt";
     if ((self = [super init])) {
         self.configuration = initConfiguration;
         self.state = [[BugsnagMetaData alloc] init];
@@ -195,6 +217,17 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
             BSGKeyVersion : NOTIFIER_VERSION,
             BSGKeyUrl : NOTIFIER_URL
         } mutableCopy];
+
+        NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(
+                                NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+        if (cacheDir) {
+            NSString *sentinelPath = [cacheDir stringByAppendingPathComponent:BSGWatchdogSentinelFileName];
+            NSString *crashPath = [cacheDir stringByAppendingPathComponent:BSGCrashSentinelFileName];
+            watchdogSentinelPath = strdup([sentinelPath UTF8String]);
+            crashSentinelPath = strdup([crashPath UTF8String]);
+            self.oomWatchdog = [[BSGOutOfMemoryWatchdog alloc] initWithSentinelPath:sentinelPath
+                                                                      configuration:configuration];
+        }
 
         self.metaDataLock = [[NSLock alloc] init];
         self.configuration.metaData.delegate = self;
@@ -293,6 +326,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
     [self.crashSentry install:self.configuration
                     apiClient:self.errorReportApiClient
                       onCrash:&BSSerializeDataCrashHandler];
+    [self computeDidCrashLastLaunch];
     [self setupConnectivityListener];
     [self updateAutomaticBreadcrumbDetectionSettings];
 
@@ -350,6 +384,10 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 #endif
 
     _started = YES;
+    if (!bsg_ksmachisBeingTraced() && self.configuration.autoNotify) {
+        [self.oomWatchdog enable];
+    }
+
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
 
     // notification not received in time on initial startup, so trigger manually
@@ -361,6 +399,35 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                                              selector:@selector(unsubscribeFromNotifications:)
                                                  name:name
                                                object:nil];
+}
+
+- (void)computeDidCrashLastLaunch {
+    const BSG_KSCrash_State *crashState = bsg_kscrashstate_currentState();
+#if TARGET_OS_TV || TARGET_OS_IPHONE
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSString *didCrashSentinelPath = [NSString stringWithUTF8String:crashSentinelPath];
+    BOOL appCrashSentinelExists = [manager fileExistsAtPath:didCrashSentinelPath];
+    BOOL handledCrashLastLaunch = appCrashSentinelExists || crashState->crashedLastLaunch;
+    if (appCrashSentinelExists) {
+        NSError *error = nil;
+        [manager removeItemAtPath:didCrashSentinelPath error:&error];
+        if (error) {
+            bsg_log_err(@"Failed to remove crash sentinel file: %@", error);
+            unlink(crashSentinelPath);
+        }
+    }
+    self.appCrashedLastLaunch = handledCrashLastLaunch || [self.oomWatchdog didOOMLastLaunch];
+    // Ignore potential false positive OOM if previous session crashed and was
+    // reported. There are two checks in place:
+    // 1. crashState->crashedLastLaunch: Accurate unless the crash callback crashes
+    // 2. crash sentinel file exists: This file is written in the event of a crash
+    //    and insures against the crash callback crashing
+    if (!handledCrashLastLaunch && [self.oomWatchdog didOOMLastLaunch]) {
+        [self notifyOutOfMemoryEvent];
+    }
+#else
+    self.appCrashedLastLaunch = crashState->crashedLastLaunch;
+#endif
 }
 
 /**
@@ -503,6 +570,32 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                              attrValue:logLevel];
 
     [self notify:exception handledState:state block:block];
+}
+
+- (void)notifyOutOfMemoryEvent {
+    static NSString *const BSGOutOfMemoryErrorClass = @"Out Of Memory";
+    static NSString *const BSGOutOfMemoryMessageFormat = @"The app was likely terminated by the operating system while in the %@";
+    NSMutableDictionary *lastLaunchInfo = [[self.oomWatchdog lastBootCachedFileInfo] mutableCopy];
+    BOOL wasInForeground = [[lastLaunchInfo valueForKeyPath:@"app.inForeground"] boolValue];
+    NSString *message = [NSString stringWithFormat:BSGOutOfMemoryMessageFormat, wasInForeground ? @"foreground" : @"background"];
+    BugsnagHandledState *handledState = [BugsnagHandledState
+        handledStateWithSeverityReason:LikelyOutOfMemory
+                              severity:BSGSeverityError
+                             attrValue:nil];
+    NSDictionary *crumbs = [self.configuration.breadcrumbs cachedBreadcrumbs];
+    if (crumbs.count > 0) {
+        lastLaunchInfo[@"breadcrumbs"] = crumbs;
+    }
+    NSDictionary *appState = @{@"oom": lastLaunchInfo, @"didOOM": @YES};
+    [self.crashSentry reportUserException:BSGOutOfMemoryErrorClass
+                                   reason:message
+                        originalException:nil
+                             handledState:[handledState toJson]
+                                 appState:appState
+                        callbackOverrides:@{}
+                                 metadata:@{}
+                                   config:@{}
+                             discardDepth:0];
 }
 
 - (void)notify:(NSException *)exception

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
@@ -44,7 +44,7 @@
 #import <AppKit/AppKit.h>
 #endif
 
-NSString *const NOTIFIER_VERSION = @"5.19.1";
+NSString *const NOTIFIER_VERSION = @"5.21.0";
 NSString *const NOTIFIER_URL = @"https://github.com/bugsnag/bugsnag-cocoa";
 NSString *const BSTabCrash = @"crash";
 NSString *const BSAttributeDepth = @"depth";

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSession.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSession.h
@@ -25,7 +25,16 @@
                        handledCount:(NSUInteger)handledCount
                      unhandledCount:(NSUInteger)unhandledCount;
 
+/**
+ * Representation used in report payloads
+ */
 - (NSDictionary *_Nonnull)toJson;
+
+/**
+ * Full representation of a session suitable for creating an identical session
+ * using initWithDictionary
+ */
+- (NSDictionary *_Nonnull)toDictionary;
 - (void)stop;
 - (void)resume;
 

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSession.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSession.m
@@ -78,6 +78,18 @@ static NSString *const kBugsnagUser = @"user";
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
+- (NSDictionary *)toDictionary {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[kBugsnagSessionId] = self.sessionId ?: @"";
+    dict[kBugsnagStartedAt] = self.startedAt ? [BSG_RFC3339DateTool stringFromDate:self.startedAt] : @"";
+    dict[kBugsnagHandledCount] = @(self.handledCount);
+    dict[kBugsnagUnhandledCount] = @(self.unhandledCount);
+    if (self.user) {
+        dict[kBugsnagUser] = [self.user toJson];
+    }
+    return dict;
+}
+
 - (void)stop {
     self.stopped = YES;
 }

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.h
@@ -15,6 +15,8 @@
 
 typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
 
+extern NSString *const BSGSessionUpdateNotification;
+
 @interface BugsnagSessionTracker : NSObject
 
 /**

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.m
@@ -18,6 +18,8 @@
  */
 NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 
+NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
+
 @interface BugsnagSessionTracker ()
 @property (weak, nonatomic) BugsnagConfiguration *config;
 @property (strong, nonatomic) BugsnagSessionFileStore *sessionStore;
@@ -62,6 +64,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     if (self.callback) {
         self.callback(nil);
     }
+    [self postUpdateNotice];
 }
 
 - (BOOL)resumeSession {
@@ -73,6 +76,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     } else {
         BOOL stopped = session.isStopped;
         [session resume];
+        [self postUpdateNotice];
         return stopped;
     }
 }
@@ -108,6 +112,8 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     if (self.callback) {
         self.callback(self.currentSession);
     }
+    [self postUpdateNotice];
+
     [self.apiClient deliverSessionsInStore:self.sessionStore];
 }
 
@@ -128,6 +134,12 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     if (self.callback) {
         self.callback(self.currentSession);
     }
+    [self postUpdateNotice];
+}
+
+- (void)postUpdateNotice {
+    [[NSNotificationCenter defaultCenter] postNotificationName:BSGSessionUpdateNotification
+                                                        object:[self.runningSession toDictionary]];
 }
 
 #pragma mark - Handling events
@@ -156,6 +168,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
         if (self.callback && (self.config.shouldAutoCaptureSessions || !session.autoCaptured)) {
             self.callback(session);
         }
+        [self postUpdateNotice];
     }
 }
 

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingApiClient.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingApiClient.m
@@ -41,6 +41,12 @@
         }
         BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc] initWithSessions:sessions];
         NSUInteger sessionCount = payload.sessions.count;
+        NSMutableDictionary *data = [payload toJson];
+
+        for (BeforeSendSession cb in self.config.beforeSendSessionBlocks) {
+            cb(data);
+        }
+
         if (sessionCount > 0) {
             NSDictionary *HTTPHeaders = @{
                                           @"Bugsnag-Payload-Version": @"1.0",
@@ -48,7 +54,7 @@
                                           @"Bugsnag-Sent-At": [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
                                           };
             [self sendItems:sessions.count
-                withPayload:[payload toJson]
+                withPayload:data
                       toURL:sessionURL
                     headers:HTTPHeaders
                onCompletion:^(NSUInteger sentCount, BOOL success, NSError *error) {

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingPayload.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingPayload.h
@@ -14,7 +14,7 @@
 
 - (instancetype)initWithSessions:(NSArray<BugsnagSession *> *)sessions;
 
-- (NSDictionary *)toJson;
+- (NSMutableDictionary *)toJson;
 
 @property NSArray<BugsnagSession *> *sessions;
 

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingPayload.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingPayload.m
@@ -28,8 +28,7 @@
 }
 
 
-- (NSDictionary *)toJson {
-    
+- (NSMutableDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     NSMutableArray *sessionData = [NSMutableArray new];
     
@@ -42,7 +41,7 @@
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BSGDictSetSafeObject(dict, BSGParseAppState(systemInfo, [Bugsnag configuration].appVersion), @"app");
     BSGDictSetSafeObject(dict, BSGParseDeviceState(systemInfo), @"device");
-    return [NSDictionary dictionaryWithDictionary:dict];
+    return dict;
 }
 
 @end

--- a/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -51,6 +51,7 @@
 #define BSG_KSSystemField_Size "size"
 #define BSG_KSSystemField_SystemName "system_name"
 #define BSG_KSSystemField_SystemVersion "system_version"
+#define BSG_KSSystemField_ClangVersion "clang_version"
 #define BSG_KSSystemField_TimeZone "time_zone"
 #define BSG_KSSystemField_BuildType "build_type"
 

--- a/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -67,4 +67,9 @@
  */
 + (NSDictionary *)systemInfo;
 
+/**
+ * The build version of the OS
+ */
++ (NSString *)osBuildVersion;
+
 @end

--- a/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -406,7 +406,7 @@
     }
     [sysInfo bsg_ksc_safeSetObject:[self stringSysctl:@"kern.version"]
                             forKey:@BSG_KSSystemField_KernelVersion];
-    [sysInfo bsg_ksc_safeSetObject:[self stringSysctl:@"kern.osversion"]
+    [sysInfo bsg_ksc_safeSetObject:[self osBuildVersion]
                             forKey:@BSG_KSSystemField_OSVersion];
     [sysInfo bsg_ksc_safeSetObject:@([self isJailbroken])
                             forKey:@BSG_KSSystemField_Jailbroken];
@@ -458,6 +458,10 @@
     [sysInfo bsg_ksc_safeSetObject:memory forKey:@BSG_KSSystemField_Memory];
 
     return sysInfo;
+}
+
++ (NSString *)osBuildVersion {
+    return [self stringSysctl:@"kern.osversion"];
 }
 
 @end

--- a/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -362,7 +362,10 @@
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSDictionary *infoDict = [mainBundle infoDictionary];
     const struct mach_header *header = _dyld_get_image_header(0);
-
+#ifdef __clang_version__
+    [sysInfo bsg_ksc_safeSetObject:@__clang_version__
+                            forKey:@BSG_KSSystemField_ClangVersion];
+#endif
 #if BSG_KSCRASH_HAS_UIDEVICE
     [sysInfo bsg_ksc_safeSetObject:[UIDevice currentDevice].systemName
                             forKey:@BSG_KSSystemField_SystemName];

--- a/cocoa/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -34,7 +34,12 @@
 		8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */; };
 		8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */; };
 		8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD11EC2A62900F7C04E /* BSGSerialization.m */; };
+		8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */; };
+		8A70D9CA22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
+		8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
+		8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */; };
 		8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */; };
+		E704F4EE2271ED1900009F4D /* BSGOutOfMemoryWatchdog.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
 		E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */; };
@@ -335,6 +340,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E704F4EE2271ED1900009F4D /* BSGOutOfMemoryWatchdog.h in CopyFiles */,
 				E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */,
 				E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */,
 				E79148271FD828E6003EFEBF /* BugsnagSession.h in CopyFiles */,
@@ -447,6 +453,9 @@
 		8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
 		8A627CD11EC2A62900F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
+		8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
+		8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
+		8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
 		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339DateTool_Tests.m; path = ../Tests/KSCrash/RFC3339DateTool_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -648,6 +657,7 @@
 				8A2C8F751C6BBEBB00846019 /* Frameworks */,
 				8A2C8F191C6BBD2300846019 /* Products */,
 				E7397DB21F83BA410034242A /* Bugsnag copy-Info.plist */,
+				E704F4ED2271ECD500009F4D /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -714,6 +724,8 @@
 				8A2C8F1D1C6BBD2300846019 /* Info.plist */,
 				E7107BB31F4C97F100BB3F98 /* KSCrash */,
 				8A2C8F321C6BBD7200846019 /* module.modulemap */,
+				8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */,
+				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 			);
 			name = Bugsnag;
 			sourceTree = SOURCE_ROOT;
@@ -738,6 +750,7 @@
 				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
 				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
 				8A120069221C36420008C9C3 /* BSGFilepathTests.m */,
+				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -757,6 +770,14 @@
 				8A2C8F6B1C6BBE9500846019 /* SystemConfiguration.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E704F4ED2271ECD500009F4D /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		E70EE0891FD7047D00FA745C /* KSCrash */ = {
@@ -949,6 +970,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7107C411F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h in Headers */,
+				8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */,
 				8A2C8F4F1C6BBE3C00846019 /* Bugsnag.h in Headers */,
 				8A2C8F5B1C6BBE3C00846019 /* BugsnagMetaData.h in Headers */,
 				8A2C8F551C6BBE3C00846019 /* BugsnagConfiguration.h in Headers */,
@@ -1105,6 +1127,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 8A2C8F0E1C6BBD2300846019;
@@ -1164,6 +1187,7 @@
 				E7107C3A1F4C97F100BB3F98 /* BSG_KSCrashDoctor.m in Sources */,
 				E7107C421F4C97F100BB3F98 /* BSG_KSCrashState.c in Sources */,
 				E72BF77B1FC869F7004BE82F /* BugsnagSession.m in Sources */,
+				8A70D9CA22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7107C5E1F4C97F100BB3F98 /* BSG_KSCrashCallCompletion.m in Sources */,
 				E7107C4D1F4C97F100BB3F98 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
 				E7107C681F4C97F100BB3F98 /* BSG_KSLogger.m in Sources */,
@@ -1214,6 +1238,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */,
 				E7B970341FD7031500590C27 /* XCTestCase+KSCrash.m in Sources */,
 				E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E70EE08D1FD705A700FA745C /* KSSafeCollections_Tests.m in Sources */,
@@ -1275,6 +1300,7 @@
 				E7397E3D1F83BC320034242A /* BSG_KSJSONCodec.c in Sources */,
 				E7397E3E1F83BC320034242A /* BSG_KSMach.c in Sources */,
 				E72BF77C1FC869F7004BE82F /* BugsnagSession.m in Sources */,
+				8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7397E3F1F83BC320034242A /* BSG_KSMach_Arm.c in Sources */,
 				E7397E401F83BC320034242A /* BSG_KSMach_Arm64.c in Sources */,
 				E7397E411F83BC320034242A /* BSG_KSMach_x86_32.c in Sources */,

--- a/cocoa/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
 		8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */; };
 		8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */; };
-		E704F4EE2271ED1900009F4D /* BSGOutOfMemoryWatchdog.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
 		E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */; };
@@ -340,7 +339,6 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
-				E704F4EE2271ED1900009F4D /* BSGOutOfMemoryWatchdog.h in CopyFiles */,
 				E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */,
 				E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */,
 				E79148271FD828E6003EFEBF /* BugsnagSession.h in CopyFiles */,
@@ -657,7 +655,6 @@
 				8A2C8F751C6BBEBB00846019 /* Frameworks */,
 				8A2C8F191C6BBD2300846019 /* Products */,
 				E7397DB21F83BA410034242A /* Bugsnag copy-Info.plist */,
-				E704F4ED2271ECD500009F4D /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -770,14 +767,6 @@
 				8A2C8F6B1C6BBE9500846019 /* SystemConfiguration.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E704F4ED2271ECD500009F4D /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */,
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		E70EE0891FD7047D00FA745C /* KSCrash */ = {
@@ -1127,7 +1116,6 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 			);
 			mainGroup = 8A2C8F0E1C6BBD2300846019;

--- a/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
@@ -1,0 +1,19 @@
+
+#import "BSGOutOfMemoryWatchdog.h"
+#import "BSG_KSSystemInfo.h"
+#import "BugsnagConfiguration.h"
+#import <XCTest/XCTest.h>
+
+@interface BSGOutOfMemoryWatchdogTests : XCTestCase
+
+@end
+
+@implementation BSGOutOfMemoryWatchdogTests
+
+- (void)testNilPathDoesNotCreateWatchdog {
+    XCTAssertNil([[BSGOutOfMemoryWatchdog alloc] init]);
+    XCTAssertNil([[BSGOutOfMemoryWatchdog alloc] initWithSentinelPath:nil
+                                                        configuration:nil]);
+}
+
+@end

--- a/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
@@ -1,0 +1,41 @@
+//
+//  BugsnagKSCrashSysInfoParserTestTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 15/05/2018.
+//  Copyright © 2018 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "BugsnagKSCrashSysInfoParser.h"
+
+@interface BugsnagKSCrashSysInfoParserTest : XCTestCase
+@end
+
+@implementation BugsnagKSCrashSysInfoParserTest
+
+- (void)testEmptyDictSerialisation {
+    // ensures that an empty dictionary parameter returns a fallback dictionary populated with at least some information
+    NSDictionary *device = BSGParseDevice(@{});
+    [self validateDeviceDict:device];
+}
+
+
+- (void)testNilDictSerialisation {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    NSDictionary *device = BSGParseDevice(nil);
+#pragma clang diagnostic pop
+    [self validateDeviceDict:device];
+}
+
+- (void)validateDeviceDict:(NSDictionary *)device {
+    XCTAssertNotNil(device);
+    XCTAssertNotNil(device[@"locale"]);
+    XCTAssertNotNil(device[@"freeDisk"]);
+    XCTAssertNotNil(device[@"simulator"]);
+}
+
+
+@end

--- a/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BugsnagThreadTest.m
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BugsnagThreadTest.m
@@ -1,0 +1,90 @@
+//
+// Created by Jamie Lynch on 02/08/2018.
+// Copyright (c) 2018 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "BugsnagCrashReport.h"
+
+@interface BugsnagThreadTest : XCTestCase
+@end
+
+@interface BugsnagCrashReport ()
+- (NSArray *)serializeThreadsWithException:(NSMutableDictionary *)exception;
+
+@property(nonatomic, readonly, copy, nullable) NSArray *threads;
+@end
+
+@implementation BugsnagThreadTest
+
+- (void)testEmptyThreads {
+    BugsnagCrashReport *report = [self generateReportWithThreads:@[]];
+    NSArray *threads = [report serializeThreadsWithException:nil];
+    XCTAssertTrue(threads.count == 0);
+}
+
+- (void)testThreadSerialisation {
+    NSArray *trace = @[
+            @{
+                    @"backtrace": @{
+                    @"contents": @[
+                            @{
+                                    @"instruction_addr": @4438096107,
+                                    @"object_addr": @4438048768,
+                                    @"object_name": @"Bugsnag Test App",
+                                    @"symbol_addr": @4438048768,
+                                    @"symbol_name": @"_mh_execute_header",
+                            }
+                    ],
+                    @"skipped": @NO,
+            },
+                    @"crashed": @YES,
+                    @"current_thread": @YES,
+                    @"index": @0
+            },
+            @{
+                    @"backtrace": @{
+                    @"contents": @[
+                            @{
+                                    @"instruction_addr": @4510040722,
+                                    @"object_addr": @4509921280,
+                                    @"object_name": @"libsystem_kernel.dylib",
+                                    @"symbol_addr": @4510040712,
+                                    @"symbol_name": @"__workq_kernreturn",
+                            }
+                    ],
+                    @"skipped": @NO,
+            },
+                    @"crashed": @NO,
+                    @"current_thread": @NO,
+                    @"index": @1
+            },
+    ];
+
+    BugsnagCrashReport *report = [self generateReportWithThreads:trace];
+    NSArray *threads = [report serializeThreadsWithException:nil];
+    XCTAssertTrue(threads.count == 2);
+
+    // first thread is crashed, should be serialised and contain 'errorReportingThread' flag
+    NSDictionary *firstThread = threads[0];
+    XCTAssertEqualObjects(@0, firstThread[@"id"]);
+    XCTAssertEqualObjects(@"cocoa", firstThread[@"type"]);
+    XCTAssertNotNil(firstThread[@"stacktrace"]);
+    XCTAssertTrue(firstThread[@"errorReportingThread"]);
+
+    // second thread is not crashed, should not contain 'errorReportingThread' flag
+    NSDictionary *secondThread = threads[1];
+    XCTAssertEqualObjects(@1, secondThread[@"id"]);
+    XCTAssertEqualObjects(@"cocoa", secondThread[@"type"]);
+    XCTAssertNotNil(secondThread[@"stacktrace"]);
+    XCTAssertNil(secondThread[@"errorReportingThread"]);
+}
+
+- (BugsnagCrashReport *)generateReportWithThreads:(NSArray *)threads {
+    return [[BugsnagCrashReport alloc] initWithKSReport:@{@"crash": @{@"threads": threads}}];
+}
+
+
+@end

--- a/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/RegisterErrorDataTest.m
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/RegisterErrorDataTest.m
@@ -1,0 +1,262 @@
+//
+// Created by Jamie Lynch on 11/06/2018.
+// Copyright (c) 2018 Bugsnag. All rights reserved.
+//
+
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+@interface RegisterErrorData
++ (instancetype)errorDataFromThreads:(NSArray *)threads;
+@property (nonatomic, strong) NSString *errorClass;
+@property (nonatomic, strong) NSString *errorMessage;
+@end
+
+@interface RegisterErrorDataTest : XCTestCase
+@end
+
+@implementation RegisterErrorDataTest
+
+
+- (void)testNilAddresses {
+    XCTAssertNil([RegisterErrorData errorDataFromThreads:nil]);
+}
+
+- (void)testEmptyAddresses {
+    XCTAssertNil([RegisterErrorData errorDataFromThreads:@[]]);
+}
+
+- (void)testEmptyCrashedThreadDict {
+    NSDictionary *thread = @{
+            @"crashed": @YES
+    };
+    XCTAssertNil([RegisterErrorData errorDataFromThreads:@[thread]]);
+}
+
+- (void)testEmptyNotableAddresses {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{}
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNil(data);
+}
+
+- (void)testEmptyContentValue {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{}
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNil(data);
+}
+
+- (void)testNilValueImplicit {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNil(data);
+}
+
+- (void)testNilValueExplicit {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": [NSNull null]
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNil(data);
+}
+
+- (void)testHasTypeAndValue{
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"Hello, World!"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNil(data);
+}
+
+- (void)testFatalError {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNotNil(data);
+    XCTAssertEqualObjects(@"fatal error", data.errorClass);
+    XCTAssertEqualObjects(@"", data.errorMessage);
+}
+
+- (void)testAssertionFailed {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"assertion failed"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNotNil(data);
+    XCTAssertEqualObjects(@"assertion failed", data.errorClass);
+    XCTAssertEqualObjects(@"", data.errorMessage);
+}
+
+- (void)testPreconditionFailed {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"precondition failed"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertNotNil(data);
+    XCTAssertEqualObjects(@"precondition failed", data.errorClass);
+    XCTAssertEqualObjects(@"", data.errorMessage);
+}
+
+- (void)testSingleMessageValue {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    },
+                    @"message": @{
+                            @"type": @"string",
+                            @"value": @"Single Message"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertEqualObjects(@"Single Message", data.errorMessage);
+}
+
+- (void)testMultiMessageValue {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    },
+                    @"message": @{
+                            @"type": @"string",
+                            @"value": @"A is for aardvark"
+                    },
+                    @"message2": @{
+                            @"type": @"string",
+                            @"value": @"Z is for zebra"
+                    },
+                    @"message3": @{
+                            @"type": @"string",
+                            @"value": @"C is for crayfish"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertEqualObjects(@"A is for aardvark | C is for crayfish | Z is for zebra", data.errorMessage);
+}
+
+- (void)testStackExcluded {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    },
+                    @"message": @{
+                            @"type": @"stack",
+                            @"value": @"0xf0924501"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertEqualObjects(@"", data.errorMessage);
+}
+
+- (void)testOtherTypesExcluded {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    },
+                    @"message": @{
+                            @"type": @"someOtherType",
+                            @"value": @"do not serialise"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertEqualObjects(@"", data.errorMessage);
+}
+
+- (void)testFilepathExcluded {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    },
+                    @"message": @{
+                            @"type": @"string",
+                            @"value": @"/usr/share/locale"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertEqualObjects(@"", data.errorMessage);
+}
+
+- (void)testForwardSlashIncluded {
+    NSDictionary *thread = @{
+            @"crashed": @YES,
+            @"notable_addresses": @{
+                    @"hello_world": @{
+                            @"type": @"string",
+                            @"value": @"fatal error"
+                    },
+                    @"message": @{
+                            @"type": @"string",
+                            @"value": @"usr/share"
+                    }
+            }
+    };
+    RegisterErrorData *data = [RegisterErrorData errorDataFromThreads:@[thread]];
+    XCTAssertEqualObjects(@"usr/share", data.errorMessage);
+}
+
+@end

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,0 +1,25 @@
+Feature: Runtime versions are included in all requests
+
+    Scenario Outline: Uncaught exception contains runtime versions for Android
+        When I launch an <platform> app which has an uncaught exception
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the payload field "events.0.device.runtimeVersions.osBuild" is not null
+        And the payload field "events.0.device.runtimeVersions.reactNative" is not null
+        And the payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
+
+        Examples:
+        | platform |
+        | Android  |
+
+    Scenario Outline: Session contains runtime versions for Android
+        When I launch an <platform> app with "StoppedSessionScenario"
+        Then I should receive 2 requests
+        And the request 0 is valid for the session tracking API
+        And the payload field "device.runtimeVersions.osBuild" is not null for request 0
+        And the payload field "device.runtimeVersions.reactNative" is not null for request 0
+        And the payload field "device.runtimeVersions.androidApiLevel" is not null for request 0
+
+        Examples:
+        | platform |
+        | Android  |


### PR DESCRIPTION
## Goal
We should collect the React Native version in `device.runtimeVersions.reactNative` for all error reports and sessions.

Note: this PR relies on the following [Android](https://github.com/bugsnag/bugsnag-android/pull/474) and [Cocoa](https://github.com/bugsnag/bugsnag-cocoa/pull/341) PRs. The Cocoa changes have been vendored in; the Android changes require installing an artefact to mavenLocal in the usual way.

## Changeset
- Updated bugsnag-cocoa to `runtime-versions-hooks` branch
- Added `beforeSendSession` callback to both Cocoa/Android which adds the react native version to the session payload
- Added a `beforeSend` block/callback which adds the react native version to the error payload
- Calculated the React Native version by concatenating the values present in the map supplied by the React Native platform

## Discussion
There are a couple of important things to note with this approach:

1. We use a `beforeSend` callback on React Native rather than a `beforeNotify` callback because this is the only callback mechanism that is guaranteed to be invoked when a fatal error occurs in the NDK.

2. Ideally we would specify callbacks in a configuration parameter that is passed into a Bugsnag constructor; however, this is not possible with the current architecture of bugsnag-react-native. Instead we specify callbacks after constructing Bugsnag, which means there is a chance that some sessions could be missing runtime version information. This is a known issue with React Native configuration in general, and is something that we should address as part of a general revamp of the notifier.

## Tests
Manually tested that the field was present in the payload for an error/session on both Android/Cocoa.

Mazerunner scenarios will be added in a separate PR to aid review.