### PR TITLE
ci: attempt fixing ci by removing unused env vars and system image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jobs:
       script: npm run test:lint:js && npm run test:unit:js && npm run test:smoke:typescript
     - stage: build
       language: android
+      dist: trusty
       android:
         components:
          - tools
@@ -24,23 +25,18 @@ jobs:
           - $HOME/.gradle/caches/
           - $HOME/.gradle/wrapper/
           - $HOME/.android/build-cache
-      env:
-        - ANDROID_TARGET=android-26 ANDROID_ABI=armeabi-v7a
-        - ADB-INSTALL_TIMEOUT=5
       before_install:
         - yes | sdkmanager "platforms;android-26"
         - yes | sdkmanager "platforms;android-23"
-      install:
-        - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-        - sudo apt-get install -y nodejs
+        - nvm install 8
       before_script:
         - npm install
         - npm install babel-cli
         - PATH="node_modules/bin:$PATH" && npm pack
       script:
         - cd examples/plain
-        - yarn add ../../bugsnag-react-native-*.tgz
-        - yarn install
+        - npm add ../../bugsnag-react-native-*.tgz
+        - npm install
         - ./node_modules/.bin/react-native link
         - cd android
         - ./gradlew lint checkstyle assembleRelease


### PR DESCRIPTION
Fixes Travis CI failing when the image updated to Xenial, by pinning to Trusty.

The changeset also removes unused env vars, and has replaced manual installation of npm with `nvm` instead.