### PR TITLE
Update bugsnag-android version to 4.14.2 to reduce amount of false positives ANR detections

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.14.0'
+    compile 'com.bugsnag:bugsnag-android:4.14.2'
     compile 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
## Goal

Reduce amount of false positives ANR detections. 
In current version (_4.14.0_) my bugsnag is full of false positives ANR detections. This was fixed in lates version (_4.14.2_) of bugsnag-android, so I would like to have this version with fix

## Changeset

- updated version of **bugsnag-android** from _4.14.0_ to _4.14.2_

### Linked issues

Fixes [#467](https://github.com/bugsnag/bugsnag-android/issues/467)
Related to [#484](https://github.com/bugsnag/bugsnag-android/pull/484)
