### PR TITLE
Remove nullability annotations to workaround androidx jetifier issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Remove nullability annotations to workaround androidx jetifier issue
+[#361](https://github.com/bugsnag/bugsnag-react-native/pull/361)
+
 ## 2.19.1 (2019-05-21)
 
 ### Bug fixes

--- a/android/src/main/java/com/bugsnag/DiagnosticsCallback.java
+++ b/android/src/main/java/com/bugsnag/DiagnosticsCallback.java
@@ -5,8 +5,6 @@ import com.bugsnag.android.MetaData;
 import com.bugsnag.android.Report;
 import com.bugsnag.android.Severity;
 
-import android.support.annotation.NonNull;
-
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 
@@ -92,7 +90,7 @@ class DiagnosticsCallback implements Callback {
     }
 
     @Override
-    public void beforeNotify(@NonNull Report report) {
+    public void beforeNotify(Report report) {
         report.getNotifier().setName(NOTIFIER_NAME);
         report.getNotifier().setURL(NOTIFIER_URL);
         report.getNotifier().setVersion(String.format("%s (Android %s)",

--- a/android/src/main/java/com/bugsnag/JavaScriptException.java
+++ b/android/src/main/java/com/bugsnag/JavaScriptException.java
@@ -2,8 +2,6 @@ package com.bugsnag;
 
 import com.bugsnag.android.JsonStream;
 
-import android.support.annotation.NonNull;
-
 import java.io.IOException;
 
 /**
@@ -24,7 +22,7 @@ class JavaScriptException extends Exception implements JsonStream.Streamable {
     }
 
     @Override
-    public void toStream(@NonNull JsonStream writer) throws IOException {
+    public void toStream(JsonStream writer) throws IOException {
         writer.beginObject();
         writer.name("errorClass").value(name);
         writer.name("message").value(getLocalizedMessage());


### PR DESCRIPTION
## Goal

Google recently migrated the Android support library into the Androidx namespace. When `enableJetifier` is set to true in a project, the binaries are rewritten to use the new package; however, this does not appear to apply to bugsnag-react-native, resulting in compilation failure as the `android.support.annotation` package does not exist.

Addresses #322 and #327 

## Design

As our use of the nullability annotations is of limited value, the imports and annotations were removed from the codebase.

## Tests

Ran in an example app with the following values set:

```
android.useAndroidX=true
android.enableJetifier=true
```
