### PR TITLE
build: update deprecated compile dependencies to use implementation/a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+This release updates the package's Gradle build script to use `api` and `implementation` rather than the deprecated `compile` syntax. If you are using v2.X of the Android Gradle Plugin, you will need to upgrade to v3.X of the [Android Gradle Plugin](https://developer.android.com/studio/releases/gradle-plugin#updating-plugin), and [upgrade your gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper).
+
+* Update deprecated compile dependencies to use implementation/api
+[#362](https://github.com/bugsnag/bugsnag-react-native/pull/362)
+
 ## 2.19.1 (2019-05-21)
 
 ### Bug fixes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,8 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:4.14.2'
-    compile 'com.facebook.react:react-native:+'
+    api 'com.bugsnag:bugsnag-android:4.14.2'
+    implementation 'com.facebook.react:react-native:+'
 }
 
 apply plugin: 'checkstyle'


### PR DESCRIPTION
## Goal

To remove the following warning:

> Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.

## Changeset

Updated the bugsnag-android dependency to use `api`, and react-native to use the [`implementation` configuration](https://developer.android.com/studio/build/dependencies).

## Tests

Ran existing CI suite.