### PR TITLE
get react native version using macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,26 @@ jobs:
         - ./node_modules/.bin/react-native link
         - cd ios
         - xcodebuild -project BugsnagReactNativeExample.xcodeproj -scheme BugsnagReactNativeExample build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -UseModernBuildSystem=NO -quiet
+    - stage: build
+      language: objective-c
+      os: osx
+      osx_image: xcode9.2
+      cache:
+        - bundler
+        - cocoapods
+      xcode_project: ./cocoa/BugsnagReactNative.xcodeproj
+      xcode_scheme: BugsnagReactNative
+      install:
+        - brew install yarn
+      before_script:
+        - npm install
+        - npm install babel-cli
+        - PATH="node_modules/bin:$PATH" && npm pack
+      script:
+        - cd examples/plain
+        - yarn add react-native@0.53.0
+        - yarn add ../../bugsnag-react-native-*.tgz
+        - yarn install
+        - ./node_modules/.bin/react-native link
+        - cd ios
+        - xcodebuild -project BugsnagReactNativeExample.xcodeproj -scheme BugsnagReactNativeExample build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -UseModernBuildSystem=NO -quiet

--- a/cocoa/BugsnagReactNative.m
+++ b/cocoa/BugsnagReactNative.m
@@ -354,8 +354,10 @@ RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *)options) {
     static dispatch_once_t onceToken;
     static NSString *BSGReactNativeVersion = nil;
     dispatch_once(&onceToken, ^{
-        #ifdef REACT_NATIVE_VERSION
-            NSDictionary *versionMap = REACT_NATIVE_VERSION;
+        #ifdef RCT_REACT_NATIVE_VERSION
+            // for react-native versions prior 0.55
+            // see https://github.com/react-native-community/releases/blob/451f8e7fa53f80daec9c2381c7984bee73efa51d/CHANGELOG.md#ios-specific-additions
+            NSDictionary *versionMap = RCT_REACT_NATIVE_VERSION;
         #else
             NSDictionary *versionMap = RCTGetReactNativeVersion();
         #endif

--- a/cocoa/BugsnagReactNative.m
+++ b/cocoa/BugsnagReactNative.m
@@ -354,7 +354,11 @@ RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *)options) {
     static dispatch_once_t onceToken;
     static NSString *BSGReactNativeVersion = nil;
     dispatch_once(&onceToken, ^{
-        NSDictionary *versionMap = RCTGetReactNativeVersion();
+        #ifdef REACT_NATIVE_VERSION
+            NSDictionary *versionMap = REACT_NATIVE_VERSION;
+        #else
+            NSDictionary *versionMap = RCTGetReactNativeVersion();
+        #endif
         NSNumber *major = versionMap[@"major"];
         NSNumber *minor = versionMap[@"minor"];
         NSNumber *patch = versionMap[@"patch"];


### PR DESCRIPTION
## Goal

Read version from macro when available otherwise use newer function

## Changeset

### Added

- `pod install` for example

### Removed

### Changed


## Tests

Manual test - Xcode build example project with 
`React (0.49.5)`


## Discussion

### Alternative Approaches

`WEAK_IMPORT_ATTRIBUTE` did not work for linking `RCTGetReactNativeVersion()`

### Outstanding Questions

### Linked issues

Fixes # https://github.com/bugsnag/bugsnag-react-native/issues/371

## Review

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

