### PR TITLE
fix: make JavaScriptException inherit from BugsnagException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+## TBD
+
+## Bug fixes
+* Make JavaScriptException inherit from BugsnagException
+  [#393](https://github.com/bugsnag/bugsnag-react-native/pull/393)
+
+* (Android) Upgrade to bugsnag-android v4.18.0
+  * Migrate dependencies to androidx
+  [#554](https://github.com/bugsnag/bugsnag-android/pull/554)
+  * Improve ANR error message information
+    [#553](https://github.com/bugsnag/bugsnag-android/pull/553)
+
 ## 2.22.5 (2019-08-09)
 
 This release add a react-native.config.js file to the package to ensure

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    api 'com.bugsnag:bugsnag-android:4.17.2'
+    api 'com.bugsnag:bugsnag-android:4.18.0'
     implementation 'com.facebook.react:react-native:+'
 }
 

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -1,10 +1,12 @@
 package com.bugsnag;
 
+import com.bugsnag.BugsnagReactNative;
 import com.bugsnag.android.BreadcrumbType;
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.InternalHooks;
+import com.bugsnag.android.JavaScriptException;
 
 import android.content.Context;
 
@@ -27,7 +29,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
     private ReactContext reactContext;
     private String libraryVersion;
     private String bugsnagAndroidVersion;
-    static final Logger logger = Logger.getLogger("bugsnag-react-native");
+    public static final Logger logger = Logger.getLogger("bugsnag-react-native");
 
     public static ReactPackage getPackage() {
         return new BugsnagPackage();

--- a/android/src/main/java/com/bugsnag/JavaScriptException.java
+++ b/android/src/main/java/com/bugsnag/JavaScriptException.java
@@ -1,5 +1,6 @@
-package com.bugsnag;
+package com.bugsnag.android;
 
+import com.bugsnag.BugsnagReactNative;
 import com.bugsnag.android.JsonStream;
 
 import java.io.IOException;
@@ -7,26 +8,28 @@ import java.io.IOException;
 /**
  * Creates a streamable exception with a JavaScript stacktrace
  */
-class JavaScriptException extends Exception implements JsonStream.Streamable {
+public class JavaScriptException extends BugsnagException implements JsonStream.Streamable {
 
     private static final String EXCEPTION_TYPE = "browserjs";
     private static final long serialVersionUID = 1175784680140218622L;
 
-    private final String name;
     private final String rawStacktrace;
 
-    JavaScriptException(String name, String message, String rawStacktrace) {
-        super(message);
-        this.name = name;
+    /**
+     * Constructs a JavaScript exception - intended for internal use only.
+     */
+    public JavaScriptException(String name, String message, String rawStacktrace) {
+        super(name, message, new StackTraceElement[]{}); // stacktrace set later on
+        super.setType(EXCEPTION_TYPE);
         this.rawStacktrace = rawStacktrace;
     }
 
     @Override
     public void toStream(JsonStream writer) throws IOException {
         writer.beginObject();
-        writer.name("errorClass").value(name);
-        writer.name("message").value(getLocalizedMessage());
-        writer.name("type").value(EXCEPTION_TYPE);
+        writer.name("errorClass").value(getName());
+        writer.name("message").value(getMessage());
+        writer.name("type").value(getType());
 
         writer.name("stacktrace");
         writer.beginArray();


### PR DESCRIPTION
## Goal

As part of https://github.com/bugsnag/bugsnag-android/pull/553 the way exceptions are serialised in bugsnag-android was altered. This was to allow the exception name/message to be altered after a `BugsnagException` object has been constructed.

As part of this change, the exception serialisation was altered so that when building an error, all `Throwable` objects must be wrapped in a `BugsnagException` if they are [not already of that type](https://github.com/bugsnag/bugsnag-android/pull/553/files#diff-04f6e695a46ee00c79f74a90c284bb41R59). This meant that `JavaScriptException#toStream()` was not invoked when serialising an error report, leading to the name being serialised as `com.bugsnag.JavaScriptException`, rather than the name of the JS error.

This changeset alters `JavaScriptException` to inherit `BugsnagException`, meaning that it is not wrapped in a `BugsnagException`, and that its custom `toStream` implementation will be invoked and the JS error serialised correctly.

## Tests

Tested manually in the example app and confirmed that `ReferenceError` was the error class and the correct stacktrace was collected.

Additional unit test coverage has also been added in the Android PR.

