### PR TITLE
feat: Include isFatal in unhandled error reports

### DIFF
--- a/src/Bugsnag.js
+++ b/src/Bugsnag.js
@@ -46,7 +46,9 @@ export class Client {
 
       ErrorUtils.setGlobalHandler((error, isFatal) => {
         if (this.config.autoNotify && this.config.shouldNotify()) {
-          this.notify(error, null, true, () => {
+          this.notify(error, (report) => {
+            report.addMetadata('Additional context', 'isFatal', isFatal)
+          }, true, () => {
             if (previousHandler) {
               // Wait 150ms before terminating app, allowing native processing
               // to complete, if any. On iOS in particular, there is no

--- a/src/__tests__/Bugsnag.test.js
+++ b/src/__tests__/Bugsnag.test.js
@@ -54,7 +54,7 @@ test('handleUncaughtErrors(): error handler calls notify(…) correctly', () => 
   c.notify = jest.fn()
   handler(new Error('boom!'), false)
 
-  expect(c.notify).toHaveBeenCalledWith(expect.any(Error), null, true, expect.any(Function), {
+  expect(c.notify).toHaveBeenCalledWith(expect.any(Error), expect.any(Function), true, expect.any(Function), {
     originalSeverity: 'error',
     severityReason: 'unhandledException',
     unhandled: true


### PR DESCRIPTION
Re-implement #400 without adding `lib` to source control and using a convenience method for updating metadata, to ensure it merges rather than overwrites.

Tested locally:
![image](https://user-images.githubusercontent.com/609579/64607391-51bc7e80-d3c0-11e9-911b-406d686312fe.png)
