### PR TITLE
Use the correct android version in Notifier payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Use the correct android version in Notifier payload
+  [bugsnag-react-native#409](https://github.com/bugsnag/bugsnag-react-native/pull/409)
+
 ## 2.23.2 (2019-09-26)
 
 ### Bug fixes

--- a/android/src/main/java/com/bugsnag/BugsnagReactNative.java
+++ b/android/src/main/java/com/bugsnag/BugsnagReactNative.java
@@ -7,6 +7,7 @@ import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.InternalHooks;
 import com.bugsnag.android.JavaScriptException;
+import com.bugsnag.android.Notifier;
 
 import android.content.Context;
 
@@ -120,7 +121,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
         }
         Client client = getClient(apiKey);
         libraryVersion = options.getString("version");
-        bugsnagAndroidVersion = client.getClass().getPackage().getSpecificationVersion();
+        bugsnagAndroidVersion = Notifier.getInstance().getVersion();
         configureRuntimeOptions(client, options);
         InternalHooks.configureClient(client);
 


### PR DESCRIPTION
## Goal

The version supplied by getSpecificationVersion() always returns 0. We should use the version
supplied by Notifier.getInstance() instead, as we know it will always be accurate, and will allow us to determine which version of bugsnag-android is actually being used for each event.

## Tests

Confirmed that in a local artefact the message now states:

>Initialized Bugsnag React Native 2.23.2/Android 4.19.1

rather than "0.0".

## Discussion

We want to update the format of our payload to include the RN/Android version separately. This change requires pipeline alterations so is not addressed in this PR.