### PR TITLE
Add dependency on Bugsnag itself if you use the core subspec

### DIFF
--- a/BugsnagReactNative.podspec
+++ b/BugsnagReactNative.podspec
@@ -27,5 +27,6 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |core|
     core.source_files = 'cocoa/BugsnagReactNative.{h,m}'
     core.public_header_files = ['cocoa/BugsnagReactNative.h']
+    core.dependency 'Bugsnag'
   end
 end


### PR DESCRIPTION
Howdy,

Noticed that if you use the 'Core' subspec with the Bugsnag pod included separately to bugsnag-react-native, then there's a build error, as the bugsnag-react-native files can't find the Bugsnag.h header, ie:

````
  pod 'BugsnagReactNative', :path => '../node_modules/bugsnag-react-native/BugsnagReactNative.podspec', :subspecs => [
    'Core'
  ]
````

<img width="932" alt="image" src="https://user-images.githubusercontent.com/397/67993566-7bde3e80-fc95-11e9-9bcb-e2c144b5d0ed.png">

### Added

Resolved it by adding a dependency to the Bugsnag pod in the core subspec.

## Tests

Project didn't build beforehand, does afterwards.

## Review

For the submitter, initial self-review:

- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
