### PR TITLE
fix(types): add missing argument to BeforeSend type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Add missing argument to `BeforeSend` type definition
+  [bugsnag-react-native#432](https://github.com/bugsnag/bugsnag-react-native/pull/432)
+
 ## 2.23.3 (2019-12-05)
 
 ### Bug fixes

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ export class Configuration {
   public toJSON(): any;
 }
 
-type BeforeSend = (report: Report) => boolean | void;
+type BeforeSend = (report: Report, error: Error) => boolean | void;
 
 export class StandardDelivery {
   public endpoint: string;

--- a/test/app.ts
+++ b/test/app.ts
@@ -3,9 +3,11 @@
 // allow the TS compiler to successfully import
 // and interact with the JS client
 
-import { Client } from './tmp/package';
+import { Client, Report } from './tmp/package';
 const client = new Client('API_KEYYY')
 client.notify(new Error('flop'))
+client.notify(new Error('flop'), (report: Report, error: Error) => false)
+client.notify(new Error('flop'), (report: Report, error: Error) => { })
 client.setUser('123', 'B. Nag', 'bugs.nag@bugsnag.com')
 client.setUser(undefined, undefined, undefined)
 client.setUser()


### PR DESCRIPTION
## Goal

Correct type definition of `BeforeSend`. Fixes #428.

## Tests

Updated type tests to verify `BeforeSend` type definitions against expected usage.

## Discussion

### Linked issues

Fixes #428.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
