### PR TITLE
Test against freshly built projects on 0.59 and 0.61 on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ android/local.properties
 android/android.iml
 test/tmp
 .gradle
+tmp-projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,46 +44,48 @@ jobs:
         -
     - stage: build
       language: objective-c
+      env:
+        - REACT_NATIVE_VERSION=0.53.0
+      name: React Native 0.53.0
       os: osx
       osx_image: xcode10
       cache:
         - bundler
-        - cocoapods
-      xcode_project: ./cocoa/BugsnagReactNative.xcodeproj
-      xcode_scheme: BugsnagReactNative
       install:
-        - brew install yarn
-      before_script:
         - npm install
         - npm install babel-cli
+      before_script:
         - PATH="node_modules/bin:$PATH" && npm pack
       script:
-        - cd examples/plain
-        - yarn add ../../bugsnag-react-native-*.tgz
-        - yarn install
-        - ./node_modules/.bin/react-native link
-        - cd ios
-        - xcodebuild -project BugsnagReactNativeExample.xcodeproj -scheme BugsnagReactNativeExample build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -UseModernBuildSystem=NO -quiet
+        - ./test/test-react-native-link-build.sh
     - stage: build
       language: objective-c
+      env:
+        - REACT_NATIVE_VERSION=0.59.10
+      name: React Native 0.59.10
       os: osx
-      osx_image: xcode9.2
+      osx_image: xcode10
       cache:
         - bundler
-        - cocoapods
-      xcode_project: ./cocoa/BugsnagReactNative.xcodeproj
-      xcode_scheme: BugsnagReactNative
       install:
-        - brew install yarn
-      before_script:
         - npm install
         - npm install babel-cli
+      before_script:
         - PATH="node_modules/bin:$PATH" && npm pack
       script:
-        - cd examples/plain
-        - yarn add react-native@0.53.0
-        - yarn add ../../bugsnag-react-native-*.tgz
-        - yarn install
-        - ./node_modules/.bin/react-native link
-        - cd ios
-        - xcodebuild -project BugsnagReactNativeExample.xcodeproj -scheme BugsnagReactNativeExample build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -UseModernBuildSystem=NO -quiet
+        - ./test/test-react-native-link-build.sh
+    - stage: build
+      language: objective-c
+      name: React Native 0.61.5
+      os: osx
+      osx_image: xcode11
+      cache:
+        - bundler
+      install:
+        - npm install
+        - npm install babel-cli
+        - gem install cocoapods
+      before_script:
+        - PATH="node_modules/bin:$PATH" && npm pack
+      script:
+        - ./test/test-react-native-pod-build.sh

--- a/test/test-react-native-link-build.sh
+++ b/test/test-react-native-link-build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e pipefail
+
+if [ -z "$REACT_NATIVE_VERSION" ]; then
+    export REACT_NATIVE_VERSION=0.59.10
+fi
+
+export PROJ_DIR=MyProject_${REACT_NATIVE_VERSION//./}
+
+mkdir -p tmp-projects
+cd tmp-projects
+echo '{}' > package.json
+npm install react-native-cli@2.0.1 --save
+./node_modules/.bin/react-native init --version="react-native@$REACT_NATIVE_VERSION" "$PROJ_DIR"
+cd "$PROJ_DIR"
+npm install ../../bugsnag-react-native-*.tgz --save
+./node_modules/.bin/react-native link
+cd ios
+xcodebuild -project "$PROJ_DIR.xcodeproj" \
+           -scheme "$PROJ_DIR" build \
+           -sdk iphonesimulator -quiet \
+           -UseModernBuildSystem=NO # https://github.com/facebook/react-native/issues/20492
+

--- a/test/test-react-native-pod-build.sh
+++ b/test/test-react-native-pod-build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e pipefail
+
+mkdir -p tmp-projects
+cd tmp-projects
+echo '{}' > package.json
+npm install react-native-cli@2.0.1 --save
+./node_modules/.bin/react-native init --version="react-native@0.61.5" MyProject61
+cd MyProject61
+npm install ../../bugsnag-react-native-*.tgz --save
+cd ios
+pod install
+
+xcodebuild -workspace MyProject61.xcworkspace \
+           -scheme MyProject61 build \
+           -sdk iphonesimulator -quiet
+


### PR DESCRIPTION
This change updates the CI build strategy to create new React Native projects for RN 0.59 and RN 0.61 and check that a linked project compiles. This removes an existing test which added the bugsnag-react-native package to an existing 0.53 project. This change should ensure newer and older versions of RN build correctly with bugsnag-react-native and that issues like #433 are caught automatically.

~This is a draft awaiting #441 being merged, which will make the build pass.~