### PR TITLE
fix(cocoa): amend RCTVersion.h include to fix podfile use case for pre-0.60

### DIFF
--- a/cocoa/BugsnagReactNative.m
+++ b/cocoa/BugsnagReactNative.m
@@ -1,7 +1,11 @@
 #import "Bugsnag.h"
 #import "BSG_KSCrashC.h"
 #import "BugsnagReactNative.h"
-#import "RCTVersion.h"
+#if __has_include(<React/RCTVersion.h>)
+#  import <React/RCTVersion.h>
+#else
+#  import "RCTVersion.h"
+#endif
 #import <React/RCTConvert.h>
 
 NSString *const BSGInfoPlistKey = @"BugsnagAPIKey";


### PR DESCRIPTION
## Goal

The include for `RCTVersion.h` isn't using the module form as in earlier versions of React Native (~0.53) this header was not in the `React/` scope. For users supplying their own Podfile, this means they'd need to add a separate directory to make this include work when built using Cocoapods.

## Changeset

### Changed

* `BugsnagReactNative.m` - added conditional include of either `<React/RCTVersion.h>` or `"RCTVersion.h"` which should work on all setups.

## Tests

* Confirmed via CI builds

### Linked issues

Fixes #442