### PR TITLE
Added BugsnagPlugin.h to podspec

### DIFF
--- a/BugsnagReactNative.podspec
+++ b/BugsnagReactNative.podspec
@@ -21,7 +21,9 @@ Pod::Spec.new do |s|
   s.source_files = 'cocoa/BugsnagReactNative.{h,m}',
                    'cocoa/vendor/bugsnag-cocoa/Source/**/*.{h,m,mm,cpp,c}',
 
-  s.public_header_files = 'cocoa/**/{Bugsnag,BugsnagReactNative,BugsnagMetaData,BugsnagConfiguration,BugsnagBreadcrumb,BugsnagCrashReport,BSG_KSCrashReportWriter}.h'
+  s.public_header_files = 'cocoa/**/BugsnagReactNative.h' + 
+                          'cocoa/**/BSG_KSCrashReportWriter.h,' + 
+                          'cocoa/**/Bugsnag{,MetaData,Configuration,Breadcrumb,CrashReport,Plugin}.h'
 
   # If Bugsnag is previously installed via CocoaPods, use the Core subspec.
   s.subspec 'Core' do |core|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 2.23.7 (TBC)
+
+### Bug fixes
+
+* Add missing `BugsnagPlugin.h` header to podspec file
+  [#450](https://github.com/bugsnag/bugsnag-react-native/pull/450)
+
 ## 2.23.6 (2020-02-10)
 
 ### Bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ make ANDROID_VERSION=X IOS_VERSION=X upgrade_vendor
 ```
 
 - Upgrade TypeScript definitions if the JavaScript has changed.
+- Update `BugsnagReactNative.podspec` if the public headers have changed inside
+  bugsnag-cocoa's own podspec.
 
 ### Release Checklist
 


### PR DESCRIPTION
## Goal

bugsnag-cocoa v5.23.0 adds the `BugsnagPlugin.h` public header that needs to be included in bugsnag-react-native's podspec to allow `BugsnagReactNative/Bugsnag.h` to be successfully imported.

## Changeset

- BugsnagReactNative.podspec - reformatted public_header_files to better match bugsnag-cocoa for ease of future updates
- CONTRIBUTING.md - added note to prompt for this to be checked in future updates.

## Tests

Verified locally by creating a fresh RN project, installing bugsnag-react-native and adding `#import <BugsnagReactNative/Bugsnag.h>` to a source file.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
