### PR TITLE
Fix syntax error in Podspec when specifying multiple public_header_paths

### DIFF
--- a/BugsnagReactNative.podspec
+++ b/BugsnagReactNative.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
   s.source_files = 'cocoa/BugsnagReactNative.{h,m}',
                    'cocoa/vendor/bugsnag-cocoa/Source/**/*.{h,m,mm,cpp,c}',
 
-  s.public_header_files = 'cocoa/**/BugsnagReactNative.h' + 
-                          'cocoa/**/BSG_KSCrashReportWriter.h,' + 
+  s.public_header_files = 'cocoa/**/BugsnagReactNative.h',
+                          'cocoa/**/BSG_KSCrashReportWriter.h',
                           'cocoa/**/Bugsnag{,MetaData,Configuration,Breadcrumb,CrashReport,Plugin}.h'
 
   # If Bugsnag is previously installed via CocoaPods, use the Core subspec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 2.23.8
+
+### Bug fixes
+
+* Fix syntax error in Podspec when specifying multiple public_header_paths
+  [#453](https://github.com/bugsnag/bugsnag-react-native/pull/453)
+
 ## 2.23.7 (2020-04-07)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Address issues preventing Cocoapods integration which regressed 

## Changeset

The current podspec fails linting

```
$ pod spec lint --fail-fast BugsnagReactNative.podspec

 -> BugsnagReactNative (2.23.7)
    - ERROR | [iOS] file patterns: The `public_header_files` pattern did not match any file.
    - ERROR | [iOS] unknown: Encountered an unknown error (Could not find a `ios` simulator (valid values: ). Ensure that Xcode -> Window -> Devices has at least one `ios` simulator listed or otherwise add one.) during validation.

Analyzed 1 podspec.

[!] The spec did not pass validation, due to 2 errors.

[!] React has been deprecated
```

### Changed
 We need to change the multiple paths in `s.public_header_files` to be comma-separated vs using the concatenation (`+`) operator which combines the multiple paths into a single path which matches no files in the repository.


## Tests

Re-ran linting to confirm `public_header_paths` issue was resolved

```
$ pod spec lint --fail-fast BugsnagReactNative.podspec

 -> BugsnagReactNative (2.23.7)
    - ERROR | [iOS] unknown: Encountered an unknown error (Could not find a `ios` simulator (valid values: ). Ensure that Xcode -> Window -> Devices has at least one `ios` simulator listed or otherwise add one.) during validation.

Analyzed 1 podspec.

[!] The spec did not pass validation, due to 1 error.

[!] React has been deprecated
```

## Discussion

### Alternative Approaches

N/A

### Outstanding Questions

- Are there plans to have the Bugsnag-cocoa repository as a dependency to avoid duplicating the public_header_paths?

### Linked issues

N/A

## Review


For the submitter, initial self-review:

- [  ] Commented on code changes inline explain the reasoning behind the approach
- [  ] Reviewed the test cases added for completeness and possible points for discussion
- [  ] A changelog entry was added for the goal of this pull request
- [  ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [  ] Initial review of the intended approach, not yet feature complete
  - [  ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
