### PR TITLE
TARGET_OS_IPHONE used when not defined

### DIFF
--- a/cocoa/vendor/bugsnag-cocoa/Source/BSGOutOfMemoryWatchdog.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BSGOutOfMemoryWatchdog.m
@@ -1,3 +1,4 @@
+#import <TargetConditionals.h>
 #if (TARGET_OS_TV || TARGET_OS_IPHONE)
 #define BSGOOMAvailable 1
 #else

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagCrashReport.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagCrashReport.m
@@ -6,6 +6,7 @@
 //
 //
 
+#import <TargetConditionals.h>
 #if TARGET_OS_MAC || TARGET_OS_TV
 #elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagKSCrashSysInfoParser.m
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Bugsnag. All rights reserved.
 //
 
+#import <TargetConditionals.h>
 #import "BugsnagKSCrashSysInfoParser.h"
 #import "Bugsnag.h"
 #import "BugsnagCollections.h"

--- a/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
+++ b/cocoa/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
@@ -41,6 +41,7 @@
 #import "BSG_KSSystemInfo.h"
 #import "BSG_KSMach.h"
 
+#import <TargetConditionals.h>
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #elif TARGET_OS_MAC

--- a/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
+++ b/cocoa/vendor/bugsnag-cocoa/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
@@ -8,6 +8,7 @@
 
 @import XCTest;
 
+#import <TargetConditionals.h>
 #import "BugsnagKSCrashSysInfoParser.h"
 NSNumber * _Nullable BSGDeviceFreeSpace(NSSearchPathDirectory directory);
 


### PR DESCRIPTION
The way that this define works is that TargetConditionals.h uses checks
that are set implcitly by clang.

Before using TARGET_OS_* TargetConditionals.h should be imported or it
won't work. Often in bugsnag this is implicitly imported by Foundation.h