### PR TITLE
fix(podfile): fix missing comma in headers list

### DIFF
--- a/BugsnagReactNative.podspec
+++ b/BugsnagReactNative.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source_files = 'cocoa/BugsnagReactNative.{h,m}',
                    'cocoa/vendor/bugsnag-cocoa/Source/**/*.{h,m,mm,cpp,c}',
 
-  s.public_header_files = 'cocoa/**/BugsnagReactNative.h' + 
+  s.public_header_files = 'cocoa/**/BugsnagReactNative.h,' +
                           'cocoa/**/BSG_KSCrashReportWriter.h,' + 
                           'cocoa/**/Bugsnag{,MetaData,Configuration,Breadcrumb,CrashReport,Plugin}.h'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 2.23.8 (TBC)
+
+* Fix missing comma in podspec headers list
+  [#456](https://github.com/bugsnag/bugsnag-react-native/pull/456)
+
 ## 2.23.7 (2020-04-07)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Adds the missing comma in the public_header_files in the podspec

## Testing

Manually tested following online enhanced native instructions to include required headers (`<BugsnagReactNative/BugsnagReactNative.h>` and `BugsnagConfiguration.h`).

### Linked issues

Related to #453 

