### PR TITLE
Update plain example react-native version to work with Xcode 13

### DIFF
--- a/examples/plain/package.json
+++ b/examples/plain/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bugsnag-react-native": "^2.12.0",
     "react": "16.8.3",
-    "react-native": "0.59.8"
+    "react-native": "0.59.9"
   },
   "jest": {
     "preset": "jest-react-native"


### PR DESCRIPTION
## Goal

React-native `0.59.8` has issues when attempting to run the plain example app in `Xcode 13` (see  [here](https://stackoverflow.com/questions/58051510/xcode-11-0-build-get-error-unknown-argument-type-attribute-in-method-r)).

This bumps the version to `0.59.9`, which fixes the issue.