### PR TITLE
fix(pod version cmd)

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -25,7 +25,7 @@ Library versions:
 
 ```
 
-- cocoapods version (if any) (`pod -v`):
+- cocoapods version (if any) (`pod --version`):
 - iOS/Android version(s):
 - simulator/emulator or physical device?:
 - debug mode or production?:

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -14,7 +14,7 @@ of `yarn list` if you are using npm):
 yarn list react-native bugsnag-react-native react-native-code-push
 ```
 
-- cocoapods version (if any) (`pod -v`):
+- cocoapods version (if any) (`pod --version`):
 - iOS/Android version(s):
 - simulator/emulator or physical device?:
 - debug mode or production?:


### PR DESCRIPTION
`pod -v` is now `pod --version`, updated in all docs accordingly.

## Goal
Brings issue templates inline with changes made to `bugsnag-cocoa` here https://github.com/bugsnag/bugsnag-cocoa/pull/746